### PR TITLE
feat: account profile - account link

### DIFF
--- a/src/components/AccountLink.test.tsx
+++ b/src/components/AccountLink.test.tsx
@@ -1,0 +1,42 @@
+import { AccountLink } from './AccountLink';
+import { render } from '../utils/test-utils';
+
+describe('AccountLink', () => {
+  it('renders account name when account name provided', () => {
+    const { queryByText } = render(
+      <AccountLink
+        account={{
+          name: 'Account Name',
+          address: '0x6B24aE0ABbeb67058D07b891aF415f288eA57Cc7',
+        }}
+      />,
+    );
+
+    expect(queryByText('Account Name')).toBeInTheDocument();
+  });
+
+  it('renders trimed address when account name is not provided', () => {
+    const { queryByText } = render(
+      <AccountLink
+        account={{
+          address: '0x6B24aE0ABbeb67058D07b891aF415f288eA57Cc7',
+        }}
+      />,
+    );
+
+    expect(queryByText('0x6B24a...57Cc7')).toBeInTheDocument();
+  });
+
+  it('renders trimed address when account name is a empty string', () => {
+    const { queryByText } = render(
+      <AccountLink
+        account={{
+          address: '0x6B24aE0ABbeb67058D07b891aF415f288eA57Cc7',
+          name: ' ',
+        }}
+      />,
+    );
+
+    expect(queryByText('0x6B24a...57Cc7')).toBeInTheDocument();
+  });
+});

--- a/src/components/AccountLink.tsx
+++ b/src/components/AccountLink.tsx
@@ -1,0 +1,27 @@
+import { Link } from '@chakra-ui/react';
+import { Link as GatsbyLink } from 'gatsby';
+import type { FunctionComponent } from 'react';
+
+import { trimAddress } from '../utils/string';
+
+export type Account = {
+  name?: string;
+  address: string;
+};
+
+export type AccountLinkProps = {
+  account: Account;
+};
+
+export const AccountLink: FunctionComponent<AccountLinkProps> = ({
+  account,
+}) => {
+  let { name } = account;
+  name = name?.trim();
+
+  return (
+    <Link as={GatsbyLink} variant="landing" to={`/account/${account.address}`}>
+      {name && name.length > 0 ? name : trimAddress(account.address)}
+    </Link>
+  );
+};

--- a/src/utils/snaps.test.ts
+++ b/src/utils/snaps.test.ts
@@ -10,7 +10,7 @@ import {
 } from './snaps';
 import { getRequestMethodMock } from './test-utils';
 
-describe('hasSnapsSupport', () => {
+describe('trimText', () => {
   it('returns `true` if the provider supports Snaps', async () => {
     const provider = getRequestMethodMock({
       // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/src/utils/snaps.test.ts
+++ b/src/utils/snaps.test.ts
@@ -10,7 +10,7 @@ import {
 } from './snaps';
 import { getRequestMethodMock } from './test-utils';
 
-describe('trimText', () => {
+describe('hasSnapsSupport', () => {
   it('returns `true` if the provider supports Snaps', async () => {
     const provider = getRequestMethodMock({
       // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/src/utils/string.test.ts
+++ b/src/utils/string.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from '@jest/globals';
+
+import { trimText, trimAddress, trimTextByHeadTail } from './string';
+
+describe('trimText', () => {
+  it('trim English text when text length exceed `100`', async () => {
+    const content =
+      'Lorem ipsum, train, feed, love and evolve your very own mischievous little pet. Modernipsum dolor sit amet scuola romana neo-fauvism idealism carolingian, rococo de stijl mail art avant-garde conceptual art relational art. Lorem ipsum, train, feed, love and evolve your very own mischievous little pet. Modernipsum dolor sit amet scuola romana neo-fauvism idealism carolingian, rococo de stijl mail art avant-garde conceptual art relational art.';
+
+    expect(trimText(content, 100)).toBe(`${content.slice(0, 100)}...`);
+  });
+
+  it('does not trim text when ltext ength shorter than `100`', async () => {
+    const content = 'Lorem ipsum';
+    expect(trimText(content, 100)).toStrictEqual(content);
+  });
+
+  it('trim text with leading space and tailing space', async () => {
+    const content = ' Lorem ipsum ';
+    expect(trimText(content, 100)).toBe('Lorem ipsum');
+  });
+
+  it('trim German text when text length exceed `100`', async () => {
+    const content =
+      'Man erzählt von dem ich mich an die Gurgel faßt wie ein Meuchelmörder, dann mein Herz näher angeht. Man erzählt von dem ich mich an die Gurgel faßt wie ein Meuchelmörder, dann mein Herz näher angeht. Man erzählt von dem ich mich an die Gurgel faßt wie ein Meuchelmörder, dann mein Herz näher angeht. Man erzählt von dem ich mich an die Gurgel faßt wie ein Meuchelmörder, dann mein Herz näher angeht. Man erzählt von dem ich mich an die Gurgel faßt wie ein Meuchelmörder, dann mein Herz näher angeht.';
+
+    expect(trimText(content, 100)).toBe(
+      `${[...content].slice(0, 100).join('')}...`,
+    );
+  });
+});
+
+describe('trimTextByHeadTail', () => {
+  it('trim English text when text length exceed `4`', async () => {
+    const content = 'aaaaa';
+
+    expect(trimTextByHeadTail(content, 2, 2)).toBe('aa...aa');
+  });
+
+  it('does not trim text when text length shorter than `4`', async () => {
+    const content = 'aa';
+    expect(trimTextByHeadTail(content, 2, 2)).toBe('aa');
+  });
+
+  it('trim text with leading space and tailing space', async () => {
+    const content = ' aa ';
+    expect(trimTextByHeadTail(content, 2, 2)).toBe('aa');
+  });
+
+  it('trim German text when text length exceed `4`', async () => {
+    const content = 'äääää';
+
+    expect(trimTextByHeadTail(content, 2, 2)).toBe(`ää...ää`);
+  });
+});
+
+describe('trimAddress', () => {
+  it('trim address when address length exceed limit', async () => {
+    const address = '0x6B24aE0ABbeb67058D07b891aF415f288eA57Cc7';
+
+    expect(trimAddress(address)).toBe('0x6B24a...57Cc7');
+  });
+});

--- a/src/utils/string.test.ts
+++ b/src/utils/string.test.ts
@@ -1,53 +1,72 @@
-import { describe, it, expect } from '@jest/globals';
-
 import { trimText, trimAddress, trimTextByHeadTail } from './string';
 
 describe('trimText', () => {
-  it('trim English text when text length exceed `100`', async () => {
+  it('trim text with default length `100` when parameter length is not provided', async () => {
     const content =
       'Lorem ipsum, train, feed, love and evolve your very own mischievous little pet. Modernipsum dolor sit amet scuola romana neo-fauvism idealism carolingian, rococo de stijl mail art avant-garde conceptual art relational art. Lorem ipsum, train, feed, love and evolve your very own mischievous little pet. Modernipsum dolor sit amet scuola romana neo-fauvism idealism carolingian, rococo de stijl mail art avant-garde conceptual art relational art.';
 
-    expect(trimText(content, 100)).toBe(`${content.slice(0, 100)}...`);
+    expect(trimText(content)).toBe(`${content.slice(0, 100)}...`);
   });
 
-  it('does not trim text when ltext ength shorter than `100`', async () => {
+  it('trim text with with the provided length', async () => {
+    const content =
+      'Lorem ipsum, train, feed, love and evolve your very own mischievous little pet. Modernipsum dolor sit amet scuola romana neo-fauvism idealism carolingian, rococo de stijl mail art avant-garde conceptual art relational art. Lorem ipsum, train, feed, love and evolve your very own mischievous little pet. Modernipsum dolor sit amet scuola romana neo-fauvism idealism carolingian, rococo de stijl mail art avant-garde conceptual art relational art.';
+
+    expect(trimText(content, 50)).toBe(`${content.slice(0, 50)}...`);
+  });
+
+  it('does not trim text when provided text is empty', async () => {
+    const content = '';
+
+    expect(trimText(content, 50)).toStrictEqual(content);
+  });
+
+  it('does not trim text when text length shorter than given length', async () => {
     const content = 'Lorem ipsum';
-    expect(trimText(content, 100)).toStrictEqual(content);
+
+    expect(trimText(content, 50)).toStrictEqual(content);
   });
 
-  it('trim text with leading space and tailing space', async () => {
+  it('trim leading space and tailing space', async () => {
     const content = ' Lorem ipsum ';
-    expect(trimText(content, 100)).toBe('Lorem ipsum');
+
+    expect(trimText(content, 50)).toBe('Lorem ipsum');
   });
 
-  it('trim German text when text length exceed `100`', async () => {
+  it('trim German text', async () => {
     const content =
       'Man erzählt von dem ich mich an die Gurgel faßt wie ein Meuchelmörder, dann mein Herz näher angeht. Man erzählt von dem ich mich an die Gurgel faßt wie ein Meuchelmörder, dann mein Herz näher angeht. Man erzählt von dem ich mich an die Gurgel faßt wie ein Meuchelmörder, dann mein Herz näher angeht. Man erzählt von dem ich mich an die Gurgel faßt wie ein Meuchelmörder, dann mein Herz näher angeht. Man erzählt von dem ich mich an die Gurgel faßt wie ein Meuchelmörder, dann mein Herz näher angeht.';
 
-    expect(trimText(content, 100)).toBe(
-      `${[...content].slice(0, 100).join('')}...`,
-    );
+    expect(trimText(content)).toBe(`${[...content].slice(0, 100).join('')}...`);
   });
 });
 
 describe('trimTextByHeadTail', () => {
-  it('trim English text when text length exceed `4`', async () => {
+  it('trim text when text length exceed the sum of parameters `heading` and `tailing`', async () => {
     const content = 'aaaaa';
 
     expect(trimTextByHeadTail(content, 2, 2)).toBe('aa...aa');
   });
 
-  it('does not trim text when text length shorter than `4`', async () => {
+  it('does not trim text when text length is not exceed the sum of parameters `heading` and `tailing`', async () => {
     const content = 'aa';
+
     expect(trimTextByHeadTail(content, 2, 2)).toBe('aa');
   });
 
-  it('trim text with leading space and tailing space', async () => {
+  it('does not trim text when provided text is empty', async () => {
+    const content = '';
+
+    expect(trimTextByHeadTail(content, 5, 5)).toStrictEqual(content);
+  });
+
+  it('trim leading space and tailing space', async () => {
     const content = ' aa ';
+
     expect(trimTextByHeadTail(content, 2, 2)).toBe('aa');
   });
 
-  it('trim German text when text length exceed `4`', async () => {
+  it('trim German text', async () => {
     const content = 'äääää';
 
     expect(trimTextByHeadTail(content, 2, 2)).toBe(`ää...ää`);
@@ -55,7 +74,7 @@ describe('trimTextByHeadTail', () => {
 });
 
 describe('trimAddress', () => {
-  it('trim address when address length exceed limit', async () => {
+  it('trim address', async () => {
     const address = '0x6B24aE0ABbeb67058D07b891aF415f288eA57Cc7';
 
     expect(trimAddress(address)).toBe('0x6B24a...57Cc7');

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,0 +1,62 @@
+/**
+ * Trim the text by the given length.
+ *
+ * @param content - The raw text content.
+ * @param length - The length to render.
+ * @returns The trimed text.
+ */
+export function trimText(content: string, length = 100) {
+  if (!content) {
+    return content;
+  }
+
+  const _content = content.trim();
+
+  const contentArr = [..._content];
+  if (contentArr.length <= length) {
+    return _content;
+  }
+
+  // Handle sepcial characters
+  return `${contentArr.slice(0, length).join('')}...`;
+}
+
+/**
+ * Trim the text by the heading length and tailing length.
+ *
+ * @param content - The raw text content.
+ * @param head - The heading length to render.
+ * @param tail - The tailing length to render.
+ * @returns The trimed text.
+ */
+export function trimTextByHeadTail(
+  content: string,
+  head: number,
+  tail: number,
+) {
+  if (!content) {
+    return content;
+  }
+
+  const _content = content.trim();
+
+  // Handle sepcial characters
+  const contentArr = [..._content];
+  if (contentArr.length <= head + tail) {
+    return _content;
+  }
+
+  return `${contentArr.slice(0, head).join('')}...${contentArr
+    .slice(-tail)
+    .join('')}`;
+}
+
+/**
+ * Renders the short address of a user.
+ *
+ * @param address - The address to render.
+ * @returns The rendered short address.
+ */
+export function trimAddress(address: string) {
+  return trimTextByHeadTail(address, 7, 5);
+}


### PR DESCRIPTION
This PR is adding a Link component for account profile

when it clicked, it will redirect user to account profile page

it will display either user name or trimmed address when user name not given