### PR TITLE
feat: account profile - account profile banner

### DIFF
--- a/src/features/account/AccountProfileBanner.test.tsx
+++ b/src/features/account/AccountProfileBanner.test.tsx
@@ -1,0 +1,9 @@
+import { AccountProfileBanner } from './AccountProfileBanner';
+import { render } from '../../utils/test-utils';
+
+describe('AccountProfileBanner', () => {
+  it('renders', () => {
+    const { queryByTestId } = render(<AccountProfileBanner />);
+    expect(queryByTestId('account-profile-banner')).toBeInTheDocument();
+  });
+});

--- a/src/features/account/AccountProfileBanner.tsx
+++ b/src/features/account/AccountProfileBanner.tsx
@@ -1,0 +1,18 @@
+import { Box } from '@chakra-ui/react';
+
+export const AccountProfileBanner = () => (
+  <Box
+    as="section"
+    id="heading"
+    bgPosition="center"
+    bgRepeat="no-repeat"
+    bgSize="cover"
+    height="250"
+    position="absolute"
+    width="100%"
+    bg={
+      'linear-gradient(93deg, rgba(221, 221, 221, 0.50) 0%, rgba(242, 242, 242, 0.50) 26.04%, rgba(220, 220, 220, 0.50) 55.79%, rgba(175, 175, 175, 0.50) 100%);'
+    }
+    data-testid="account-profile-banner"
+  ></Box>
+);

--- a/src/features/account/AccountProfileBanner.tsx
+++ b/src/features/account/AccountProfileBanner.tsx
@@ -14,5 +14,5 @@ export const AccountProfileBanner = () => (
       'linear-gradient(93deg, rgba(221, 221, 221, 0.50) 0%, rgba(242, 242, 242, 0.50) 26.04%, rgba(220, 220, 220, 0.50) 55.79%, rgba(175, 175, 175, 0.50) 100%);'
     }
     data-testid="account-profile-banner"
-  ></Box>
+  />
 );

--- a/src/features/account/index.ts
+++ b/src/features/account/index.ts
@@ -1,0 +1,1 @@
+export * from './AccountProfileBanner';


### PR DESCRIPTION
Add Account Profile Banner component for display a banner on account profile page

`Note: design and colour is not confirmed`

<img width="696" alt="image" src="https://github.com/MetaMask/permissionless-snaps-directory/assets/102275989/89a97429-0aef-446b-866a-396dafe0e081">
