### PR TITLE
feat: account profile - jazz icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@lingui/core": "^4.4.2",
     "@lingui/macro": "^4.4.2",
     "@lingui/react": "^4.4.2",
+    "@metamask/jazzicon": "^2.0.0",
     "@metamask/logo": "^3.1.1",
     "@metamask/providers": "^14.0.0",
     "@metamask/snaps-controllers": "^3.0.0",

--- a/src/components/JazzIcon.test.tsx
+++ b/src/components/JazzIcon.test.tsx
@@ -1,0 +1,48 @@
+import mmJazzIcon from '@metamask/jazzicon';
+import { render as renderComponent } from '@testing-library/react';
+import React from 'react';
+
+import { JazzIcon } from './JazzIcon';
+import { render } from '../utils/test-utils';
+
+jest.mock('@metamask/jazzicon');
+
+describe('JazzIcon', () => {
+  beforeEach(() => {
+    mmJazzIcon.mockClear();
+    // eslint-disable-next-line no-restricted-globals
+    mmJazzIcon.mockImplementation(() => document.createElement('div'));
+  });
+
+  it('renders', async () => {
+    const address = '0x6B24aE0ABbeb67058D07b891aF415f288eA57Cc7';
+    const size = 100;
+    const addr = address.trim().slice(2, 10);
+    const seed = parseInt(addr, 16);
+
+    const { queryByTestId } = render(
+      <JazzIcon address={address} size={size} />,
+    );
+
+    expect(mmJazzIcon).toHaveBeenCalledTimes(1);
+    expect(mmJazzIcon).toHaveBeenCalledWith(size, seed);
+    expect(queryByTestId('jazzicon')).toBeInTheDocument();
+  });
+
+  it('does not renders MetaMask jazzicon if ref is null', async () => {
+    const useRefSpy = jest.spyOn(React, 'useRef');
+    useRefSpy.mockReturnValue(
+      null as unknown as React.MutableRefObject<unknown>,
+    );
+
+    const address = '0x6B24aE0ABbeb67058D07b891aF415f288eA57Cc7';
+    const size = 100;
+
+    const { queryByTestId } = renderComponent(
+      <JazzIcon address={address} size={size} />,
+    );
+
+    expect(queryByTestId('jazzicon')).toBeInTheDocument();
+    expect(mmJazzIcon).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/components/JazzIcon.tsx
+++ b/src/components/JazzIcon.tsx
@@ -1,0 +1,32 @@
+import { Box } from '@chakra-ui/react';
+import Jazzicon from '@metamask/jazzicon';
+import { type FunctionComponent, useRef, useEffect } from 'react';
+
+export type JazzIconProps = {
+  address: string;
+  size: number;
+};
+
+export const JazzIcon: FunctionComponent<JazzIconProps> = ({
+  address,
+  size,
+}) => {
+  const ref = useRef<HTMLDivElement>();
+  const addr = address.trim().slice(2, 10);
+  const seed = parseInt(addr, 16);
+
+  useEffect(() => {
+    if (ref?.current) {
+      ref.current.innerHTML = '';
+      ref.current.appendChild(Jazzicon(size, seed));
+    }
+  }, [ref, seed, size]);
+
+  return (
+    <Box
+      data-testid="jazzicon"
+      ref={ref as React.MutableRefObject<HTMLDivElement>}
+      sx={{ div: { borderRadius: `${size}px!important` } }}
+    />
+  );
+};

--- a/src/components/JazzIcon.tsx
+++ b/src/components/JazzIcon.tsx
@@ -26,7 +26,7 @@ export const JazzIcon: FunctionComponent<JazzIconProps> = ({
     <Box
       data-testid="jazzicon"
       ref={ref as React.MutableRefObject<HTMLDivElement>}
-      sx={{ div: { borderRadius: `${size}px!important` } }}
+      sx={{ div: { borderRadius: `50%!important` } }}
     />
   );
 };

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -15,3 +15,4 @@ export * from './PostInstallModal';
 export * from './SnapAvatar';
 export * from './SnapsProvider';
 export * from './SnapWebsiteButton';
+export * from './JazzIcon';

--- a/src/types/vendor/@metamask/jazzicon.d.ts
+++ b/src/types/vendor/@metamask/jazzicon.d.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/unambiguous
+declare module '@metamask/jazzicon';

--- a/src/types/vendor/@metamask/jazzicon.d.ts
+++ b/src/types/vendor/@metamask/jazzicon.d.ts
@@ -1,2 +1,4 @@
 // eslint-disable-next-line import/unambiguous
-declare module '@metamask/jazzicon';
+declare module '@metamask/jazzicon' {
+  export default function jazzicon(diameter: number, seed: number): HTMLElement;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4916,6 +4916,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/jazzicon@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@metamask/jazzicon@npm:2.0.0"
+  dependencies:
+    color: ^0.11.3
+    mersenne-twister: ^1.1.0
+  checksum: 0b5add49e8d28270e4f8ca6159aa4ea0848f70cbb1cb217de2b0c13799a45fb27b8a6f0b3f72b6a76cbb55446764f79daf71e7d2a830a14b8e5e54d5e57bf7d1
+  languageName: node
+  linkType: hard
+
 "@metamask/json-rpc-engine@npm:^7.0.0, @metamask/json-rpc-engine@npm:^7.1.1, @metamask/json-rpc-engine@npm:^7.3.0":
   version: 7.3.0
   resolution: "@metamask/json-rpc-engine@npm:7.3.0"
@@ -5120,6 +5130,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.0.0
     "@metamask/eslint-config-nodejs": ^12.0.0
     "@metamask/eslint-config-typescript": ^12.0.0
+    "@metamask/jazzicon": ^2.0.0
     "@metamask/logo": ^3.1.1
     "@metamask/providers": ^14.0.0
     "@metamask/snaps-controllers": ^3.0.0
@@ -10446,7 +10457,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-convert@npm:^1.9.0":
+"color-convert@npm:^1.3.0, color-convert@npm:^1.9.0":
   version: 1.9.3
   resolution: "color-convert@npm:1.9.3"
   dependencies:
@@ -10478,6 +10489,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"color-string@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "color-string@npm:0.3.0"
+  dependencies:
+    color-name: ^1.0.0
+  checksum: cc65013a94d399ddcb81b3b4b6e0d2166cbaa77311260ff6271f215a286d3db58ab3a217bdb175f8b9dd95f9ea7ac94f71a595af6bcd3b6a02fea6e75ddaf5fb
+  languageName: node
+  linkType: hard
+
 "color-string@npm:^1.9.0":
   version: 1.9.1
   resolution: "color-string@npm:1.9.1"
@@ -10501,6 +10521,17 @@ __metadata:
   version: 2.0.2
   resolution: "color2k@npm:2.0.2"
   checksum: a024d05c0eb24c6cf4f50b73fc948734ebd8cd0ce1fcfd17f4a17e6965c29764fa4b528161de4e65939d6fc32b3063d496c327eb0f48c084b4d79707ddb5965f
+  languageName: node
+  linkType: hard
+
+"color@npm:^0.11.3":
+  version: 0.11.4
+  resolution: "color@npm:0.11.4"
+  dependencies:
+    clone: ^1.0.2
+    color-convert: ^1.3.0
+    color-string: ^0.3.0
+  checksum: a6f624fd159e9311a6c1c86ac05b5b550c98e2d1e5646e032b8481e5e113127c06a84678b91c89c96b11b58c1c723dd9766b1b02cb2d441c6212a0f7cb3dad73
   languageName: node
   linkType: hard
 
@@ -18219,6 +18250,13 @@ __metadata:
   version: 1.4.1
   resolution: "merge2@npm:1.4.1"
   checksum: 7268db63ed5169466540b6fb947aec313200bcf6d40c5ab722c22e242f651994619bcd85601602972d3c85bd2cc45a358a4c61937e9f11a061919a1da569b0c2
+  languageName: node
+  linkType: hard
+
+"mersenne-twister@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "mersenne-twister@npm:1.1.0"
+  checksum: 7de1940ded117f2aad9320ae4d21d647b0ecf0667abbadcfe6a2835c669feb674ef46cb7a72da7af69a56d8b19e50e95e2fb7ef6d780efab7a6acd4d87f4cb2d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR is adding the metamask/JazzIcon module into the project

and wrap the jazzicon with Box component to have override the border-radius

`Note: Design is not confirm, jazz icon is a temp solution`

![image](https://github.com/MetaMask/permissionless-snaps-directory/assets/102275989/5d674c45-66a7-49c0-b5e0-3723ee5588e8)
