### PR TITLE
fix: aau access account profile

### DIFF
--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -33,7 +33,7 @@ msgstr ""
 msgid "Access abilities"
 msgstr ""
 
-#: src/pages/account/[address].tsx
+#: src/pages/account/index.tsx
 msgid "Account Profile"
 msgstr ""
 
@@ -169,7 +169,7 @@ msgstr ""
 msgid "Discover Snaps"
 msgstr ""
 
-#: src/pages/account/[address].tsx
+#: src/pages/account/index.tsx
 msgid "Discover the MetaMask Snaps Directory Account Profile page."
 msgstr ""
 
@@ -185,7 +185,7 @@ msgstr ""
 msgid "Dropdown"
 msgstr ""
 
-#: src/pages/account/[address].tsx
+#: src/pages/account/index.tsx
 msgid "Edit Profile"
 msgstr ""
 
@@ -328,7 +328,7 @@ msgstr ""
 msgid "MetaMask"
 msgstr ""
 
-#: src/pages/account/[address].tsx
+#: src/pages/account/index.tsx
 msgid "MetaMask Snaps Directory - Account Profile"
 msgstr ""
 

--- a/src/pages/account/index.test.tsx
+++ b/src/pages/account/index.test.tsx
@@ -1,7 +1,7 @@
 import { describe } from '@jest/globals';
 import { getAddress } from 'viem';
 
-import AccountProfilePage, { Head } from './[address]';
+import AccountProfilePage, { Head } from '.';
 import { render, getMockSiteMetadata } from '../../utils/test-utils';
 
 jest.mock('../../features/account/components/AccountInfo', () => ({
@@ -23,8 +23,13 @@ describe('Account Profile page', () => {
   it('renders', async () => {
     const address = '0x6B24aE0ABbeb67058D07b891aF415f288eA57Cc7';
     mockGetAddress.mockReturnValue(address);
+    const mockLocationSearchParam = {
+      search: new URLSearchParams({ address }),
+    };
 
-    const { queryByText } = render(<AccountProfilePage params={{ address }} />);
+    const { queryByText } = render(
+      <AccountProfilePage location={mockLocationSearchParam} />,
+    );
 
     expect(
       queryByText("The page you're looking for can't be found."),
@@ -33,12 +38,16 @@ describe('Account Profile page', () => {
   });
 
   it('renders not found page if parameter `address` is incorrect', async () => {
+    const address = '0x6B24aE0ABbeb67058D07b891aF415f288eA57Cc7';
     mockGetAddress.mockImplementation(() => {
       throw new Error('Incorrect address');
     });
+    const mockLocationSearchParam = {
+      search: new URLSearchParams({ address }),
+    };
 
     const { queryByText } = render(
-      <AccountProfilePage params={{ address: '0x6B24aE0ABbeb' }} />,
+      <AccountProfilePage location={mockLocationSearchParam} />,
     );
 
     expect(

--- a/src/pages/account/index.tsx
+++ b/src/pages/account/index.tsx
@@ -36,7 +36,7 @@ const AccountPage: FunctionComponent<AccountPageProps> = ({ location }) => {
             <Link
               as={GatsbyLink}
               variant="landing"
-              to={`/account/${address}/edit`}
+              to={`/account/edit?address=${address}`}
             >
               <Trans>Edit Profile</Trans>
             </Link>

--- a/src/pages/account/index.tsx
+++ b/src/pages/account/index.tsx
@@ -14,13 +14,14 @@ import { type Fields, parseAddress } from '../../utils';
 import NotFound from '../404';
 
 type AccountPageProps = {
-  params: {
-    address: Hex;
+  location: {
+    search: Record<string, string> | URLSearchParams | undefined;
   };
 };
 
-const AccountPage: FunctionComponent<AccountPageProps> = ({ params }) => {
-  const address = parseAddress(params.address);
+const AccountPage: FunctionComponent<AccountPageProps> = ({ location }) => {
+  const params = new URLSearchParams(location.search);
+  const address = parseAddress(params.get('address') as Hex);
   if (!address) {
     return <NotFound />;
   }


### PR DESCRIPTION
## Description
Fixing account profile page to use static page , rather than dynamic page
Hence, the address will gather from query string

### Related ticket

Fixes #
Fixing account profile page not render correct if it host in static hosting solution

### Type of change

- [ ] Chore
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
