### PR TITLE
fix: slider unit test

### DIFF
--- a/src/components/CheckboxWithSlider.test.tsx
+++ b/src/components/CheckboxWithSlider.test.tsx
@@ -2,6 +2,8 @@ import { act } from '@testing-library/react';
 
 import {
   CheckboxWithSlider,
+  getTextAlignmentForSlider,
+  getSliderTrackColor,
   type CheckboxWithSliderProps,
 } from './CheckboxWithSlider';
 import { render } from '../utils/test-utils';
@@ -25,7 +27,7 @@ const defaultProps: CheckboxWithSliderProps = {
 
 describe('CheckboxWithSlider', () => {
   it('renders CheckboxWithSlider component', async () => {
-    const { queryByText, getByTestId } = await act(
+    const { queryByText, queryByTestId } = await act(
       async () =>
         await act(() =>
           render(<CheckboxWithSlider {...defaultProps}></CheckboxWithSlider>),
@@ -34,9 +36,30 @@ describe('CheckboxWithSlider', () => {
 
     expect(queryByText('Test Checkbox')).toBeInTheDocument();
     expect(queryByText('Test Description')).toBeInTheDocument();
-    expect(getByTestId('slider')).toBeInTheDocument();
+    expect(queryByTestId('slider')).toBeInTheDocument();
     expect(queryByText('Label1')).toBeInTheDocument();
     expect(queryByText('Label2')).toBeInTheDocument();
     expect(queryByText('Label3')).toBeInTheDocument();
+  });
+
+  describe('getTextAlignmentForSlider', () => {
+    it('return left if index < midIndex', async () => {
+      expect(getTextAlignmentForSlider(0, 1)).toBe('left');
+    });
+    it('return center if index = midIndex', async () => {
+      expect(getTextAlignmentForSlider(0, 0)).toBe('center');
+    });
+    it('return right if index > midIndex', async () => {
+      expect(getTextAlignmentForSlider(1, 0)).toBe('right');
+    });
+  });
+
+  describe('getSliderTrackColor', () => {
+    it('return error.default if sliderValue < midValue', async () => {
+      expect(getSliderTrackColor(0, 1)).toBe('error.default');
+    });
+    it('return infor.default if sliderValue >= midValue', async () => {
+      expect(getSliderTrackColor(0, 0)).toBe('info.default');
+    });
   });
 });

--- a/src/components/CheckboxWithSlider.tsx
+++ b/src/components/CheckboxWithSlider.tsx
@@ -10,7 +10,7 @@ import {
   VStack,
   HStack,
 } from '@chakra-ui/react';
-import { type FunctionComponent, useState } from 'react';
+import { type FunctionComponent, useState, useEffect } from 'react';
 
 export type CheckboxWithSliderProps = {
   title: string;
@@ -24,6 +24,25 @@ export type SliderConfig = {
   minValue: number;
   maxValue: number;
   stepSize: number;
+};
+
+export const getTextAlignmentForSlider = (
+  index: number,
+  midIndex: number,
+): ResponsiveValue<any> => {
+  if (index === midIndex) {
+    return 'center';
+  } else if (index > midIndex) {
+    return 'right';
+  }
+  return 'left';
+};
+
+export const getSliderTrackColor = (
+  sliderValue: number,
+  midValue: number,
+): ResponsiveValue<any> => {
+  return sliderValue < midValue ? 'error.default' : 'info.default';
 };
 
 /**
@@ -52,21 +71,12 @@ export const CheckboxWithSlider: FunctionComponent<CheckboxWithSliderProps> = ({
 
   const [sliderValue, setSliderValue] = useState<number>(midValue);
 
-  const handleSliderChange = (value: number) => {
-    setSliderValue(value);
-    onSliderChange(value);
-  };
+  useEffect(() => {
+    onSliderChange(sliderValue);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sliderValue]);
 
-  const getTextAlignmentForSlider = (index: number): ResponsiveValue<any> => {
-    const midIndex = (sliderLabels.length - 1) / 2;
-    let textAlign = 'left';
-    if (index === midIndex) {
-      textAlign = 'center';
-    } else if (index > midIndex) {
-      textAlign = 'right';
-    }
-    return textAlign;
-  };
+  const midIndex = (sliderLabels.length - 1) / 2;
 
   return (
     <Box
@@ -87,28 +97,30 @@ export const CheckboxWithSlider: FunctionComponent<CheckboxWithSliderProps> = ({
           <Text variant="small-description">{description}</Text>
         </VStack>
         <HStack alignItems="baseline" width="100%" height="1rem">
-          <Slider
-            data-testid="slider"
-            value={sliderValue}
-            min={sliderConfig.minValue}
-            max={sliderConfig.maxValue}
-            step={sliderConfig.stepSize}
-            onChange={(value) => handleSliderChange(value)}
-          >
-            <SliderTrack>
-              <SliderFilledTrack
-                bg={sliderValue < midValue ? 'error.default' : 'info.default'}
-              />
-            </SliderTrack>
-            <SliderThumb boxSize={5} />
-          </Slider>
+          <div data-testid="slider-wrapper">
+            <Slider
+              data-testid="slider"
+              min={sliderConfig.minValue}
+              max={sliderConfig.maxValue}
+              step={sliderConfig.stepSize}
+              onChange={setSliderValue}
+              value={sliderValue}
+            >
+              <SliderTrack>
+                <SliderFilledTrack
+                  bg={getSliderTrackColor(sliderValue, midValue)}
+                />
+              </SliderTrack>
+              <SliderThumb boxSize={5} />
+            </Slider>
+          </div>
         </HStack>
         <HStack width="100%">
           {sliderLabels.map((sliderLabel, index) => (
             <Text
               variant="small-description"
               key={index}
-              textAlign={getTextAlignmentForSlider(index)}
+              textAlign={getTextAlignmentForSlider(index, midIndex)}
               flexGrow={1}
             >
               {sliderLabel}


### PR DESCRIPTION
## Description
The PR is to fixing the missing unit test

- missing test case on handleSliderChange => overcome by using use effect react hook to trace the slide value, and call onSliderChange when state updated
- missing test case on bg change of slider track => overcome by create a outside fn to return the value, and test that function
- missing test case on getTextAlignmentForSlider => overcome by move the fn outside of the components, and test that function

**Notes:**
The components should de-couple in smaller components for easier testing


### Related ticket

Fixes #
Fixing the missing unit test in slider

### Type of change

- [ ] Chore
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
