### PR TITLE
feat: aau i access my account profile

### DIFF
--- a/src/__mocks__/connectkit.tsx
+++ b/src/__mocks__/connectkit.tsx
@@ -21,16 +21,20 @@ export type MockConnectKitButtonCustomProps = {
   mockEnsName?: string | null;
 };
 
+export const mockShowModel = jest.fn();
+
+export const mockGetIsConnected = jest.fn().mockReturnValueOnce(false);
+
 export const MockConnectKitButtonCustom: FunctionComponent<
   MockConnectKitButtonCustomProps
-> = ({ children, mockIsConnected = false, mockEnsName = null }) => {
+> = ({ children }) => {
   return (
     <div className="mock-connectkit-button-custom">
       {children({
-        isConnected: mockIsConnected,
-        show: jest.fn(),
+        isConnected: mockGetIsConnected(),
+        show: mockShowModel,
         truncatedAddress: '0x...',
-        ensName: mockEnsName,
+        ensName: 'fake.ens.name',
       })}
     </div>
   );

--- a/src/__mocks__/connectkit.tsx
+++ b/src/__mocks__/connectkit.tsx
@@ -10,38 +10,4 @@ export const MockConnectKitProvider: FunctionComponent<
   return <div className="mock-connectkit-provider">{children}</div>;
 };
 
-export type MockConnectKitButtonCustomProps = {
-  children: (props: {
-    isConnected: boolean;
-    show: () => void;
-    truncatedAddress: string;
-    ensName: string | null;
-  }) => ReactNode;
-  mockIsConnected?: boolean;
-  mockEnsName?: string | null;
-};
-
-export const mockShowModel = jest.fn();
-
-export const mockGetIsConnected = jest.fn().mockReturnValueOnce(false);
-
-export const MockConnectKitButtonCustom: FunctionComponent<
-  MockConnectKitButtonCustomProps
-> = ({ children }) => {
-  return (
-    <div className="mock-connectkit-button-custom">
-      {children({
-        isConnected: mockGetIsConnected(),
-        show: mockShowModel,
-        truncatedAddress: '0x...',
-        ensName: 'fake.ens.name',
-      })}
-    </div>
-  );
-};
-
-export const ConnectKitButton = {
-  Custom: MockConnectKitButtonCustom,
-};
-
 export const ConnectKitProvider = MockConnectKitProvider;

--- a/src/__mocks__/connectkit.tsx
+++ b/src/__mocks__/connectkit.tsx
@@ -10,4 +10,32 @@ export const MockConnectKitProvider: FunctionComponent<
   return <div className="mock-connectkit-provider">{children}</div>;
 };
 
+export type MockConnectKitButtonCustomProps = {
+  children: (props: {
+    isConnected: boolean;
+    show: () => void;
+    truncatedAddress: string;
+    ensName: string | null;
+  }) => ReactNode;
+};
+
+export const MockConnectKitButtonCustom: FunctionComponent<
+  MockConnectKitButtonCustomProps
+> = ({ children }) => {
+  return (
+    <div className="mock-connectkit-button-custom">
+      {children({
+        isConnected: false,
+        show: jest.fn(),
+        truncatedAddress: '0x...',
+        ensName: 'mock.ens.name',
+      })}
+    </div>
+  );
+};
+
+export const ConnectKitButton = {
+  Custom: MockConnectKitButtonCustom,
+};
+
 export const ConnectKitProvider = MockConnectKitProvider;

--- a/src/components/ConnectButton.test.tsx
+++ b/src/components/ConnectButton.test.tsx
@@ -1,10 +1,24 @@
 import { act } from '@testing-library/react';
 import { navigate } from 'gatsby';
+import type { FunctionComponent } from 'react';
 
 import { ConnectButton } from './ConnectButton';
-// eslint-disable-next-line jest/no-mocks-import
-import { mockGetIsConnected, mockShowModel } from '../__mocks__/connectkit';
 import { render } from '../utils/test-utils';
+
+const mockShowModel = jest.fn();
+const mockGetIsConnected = jest.fn().mockReturnValueOnce(false);
+
+jest.mock('connectkit', () => ({
+  ConnectKitButton: {
+    Custom: ({ children }: { children: FunctionComponent }) =>
+      children({
+        isConnected: mockGetIsConnected(),
+        show: mockShowModel,
+        truncatedAddress: '0x...',
+        ensName: 'mock.ens.name',
+      }),
+  },
+}));
 
 describe('ConnectKitButton.Custom', () => {
   it('renders', async () => {
@@ -33,7 +47,7 @@ describe('ConnectKitButton.Custom', () => {
 
     const { getByText } = render(<ConnectButton />);
 
-    const button = getByText('fake.ens.name');
+    const button = getByText('mock.ens.name');
 
     await act(async () => act(() => button.click()));
 

--- a/src/components/ConnectButton.test.tsx
+++ b/src/components/ConnectButton.test.tsx
@@ -21,7 +21,7 @@ jest.mock('connectkit', () => ({
 }));
 
 describe('ConnectKitButton.Custom', () => {
-  it('renders', async () => {
+  it('renders', () => {
     const { queryByText } = render(<ConnectButton />);
 
     expect(queryByText('Connect')).toBeInTheDocument();

--- a/src/components/ConnectButton.test.tsx
+++ b/src/components/ConnectButton.test.tsx
@@ -1,10 +1,43 @@
+import { act } from '@testing-library/react';
+import { navigate } from 'gatsby';
+
 import { ConnectButton } from './ConnectButton';
+// eslint-disable-next-line jest/no-mocks-import
+import { mockGetIsConnected, mockShowModel } from '../__mocks__/connectkit';
 import { render } from '../utils/test-utils';
 
 describe('ConnectKitButton.Custom', () => {
-  it('renders', () => {
+  it('renders', async () => {
     const { queryByText } = render(<ConnectButton />);
 
     expect(queryByText('Connect')).toBeInTheDocument();
+  });
+
+  it('trigger showModal when account is not connected', async () => {
+    mockGetIsConnected.mockReset();
+    mockGetIsConnected.mockReturnValueOnce(false);
+
+    const { getByText } = render(<ConnectButton />);
+
+    const button = getByText('Connect');
+
+    await act(async () => act(() => button.click()));
+
+    expect(mockShowModel).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledTimes(0);
+  });
+
+  it('trigger navigate when account is connected', async () => {
+    mockGetIsConnected.mockReset();
+    mockGetIsConnected.mockReturnValueOnce(true);
+
+    const { getByText } = render(<ConnectButton />);
+
+    const button = getByText('fake.ens.name');
+
+    await act(async () => act(() => button.click()));
+
+    expect(mockShowModel).toHaveBeenCalledTimes(0);
+    expect(navigate).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/ConnectButton.tsx
+++ b/src/components/ConnectButton.tsx
@@ -1,13 +1,19 @@
 import { ConnectKitButton } from 'connectkit';
+import { navigate } from 'gatsby';
 import type { FunctionComponent } from 'react';
 
 import { ConnectButtonInner } from './ConnectButtonInner';
 
 export const ConnectButton: FunctionComponent = () => (
   <ConnectKitButton.Custom>
-    {({ isConnected, show, truncatedAddress, ensName }) => (
+    {({ isConnected, show, truncatedAddress, ensName, address }) => (
       <ConnectButtonInner
-        handleOnClick={show}
+        handleOnClick={
+          isConnected
+            ? async () =>
+                navigate(`/account/?address=${address}`, { replace: true })
+            : show
+        }
         isConnected={isConnected}
         truncatedAddress={truncatedAddress}
         ensName={ensName}

--- a/src/pages/account/index.test.tsx
+++ b/src/pages/account/index.test.tsx
@@ -1,5 +1,6 @@
 import { describe } from '@jest/globals';
 import { getAddress } from 'viem';
+import { useAccount } from 'wagmi';
 
 import AccountProfilePage, { Head } from '.';
 import { render, getMockSiteMetadata } from '../../utils/test-utils';
@@ -12,33 +13,49 @@ jest.mock('viem', () => ({
   getAddress: jest.fn(),
 }));
 
+jest.mock('wagmi', () => ({
+  useAccount: jest.fn(),
+}));
+
 describe('Account Profile page', () => {
   let mockGetAddress: jest.Mock;
+  let mockUseAccount: jest.Mock;
 
   beforeEach(() => {
     mockGetAddress = getAddress as jest.Mock;
+    mockUseAccount = useAccount as jest.Mock;
     mockGetAddress.mockClear();
+    mockUseAccount.mockClear();
   });
 
   it('renders', async () => {
     const address = '0x6B24aE0ABbeb67058D07b891aF415f288eA57Cc7';
     mockGetAddress.mockReturnValue(address);
+    mockUseAccount.mockReturnValue({
+      address: null,
+      isConnected: false,
+    });
+
     const mockLocationSearchParam = {
       search: new URLSearchParams({ address }),
     };
 
-    const { queryByText } = render(
+    const { queryByText, queryByTestId } = render(
       <AccountProfilePage location={mockLocationSearchParam} />,
     );
 
     expect(
       queryByText("The page you're looking for can't be found."),
     ).not.toBeInTheDocument();
-    expect(queryByText('Edit Profile')).toBeInTheDocument();
+    expect(queryByTestId('account-info')).toBeInTheDocument();
   });
 
-  it('renders not found page if parameter `address` is incorrect', async () => {
+  it('renders not found page if query parameter `address` is incorrect', async () => {
     const address = '0x6B24aE0ABbeb67058D07b891aF415f288eA57Cc7';
+    mockUseAccount.mockReturnValue({
+      address: null,
+      isConnected: false,
+    });
     mockGetAddress.mockImplementation(() => {
       throw new Error('Incorrect address');
     });
@@ -46,13 +63,70 @@ describe('Account Profile page', () => {
       search: new URLSearchParams({ address }),
     };
 
-    const { queryByText } = render(
+    const { queryByText, queryByTestId } = render(
       <AccountProfilePage location={mockLocationSearchParam} />,
     );
 
     expect(
       queryByText("The page you're looking for can't be found."),
     ).toBeInTheDocument();
+    expect(queryByTestId('account-info')).not.toBeInTheDocument();
+  });
+
+  it('renders edit button if account connected and connected address equal to query parameter `address`', async () => {
+    const address = '0x6B24aE0ABbeb67058D07b891aF415f288eA57Cc7';
+    mockGetAddress.mockReturnValue(address);
+    mockUseAccount.mockReturnValue({
+      address,
+      isConnected: true,
+    });
+
+    const mockLocationSearchParam = {
+      search: new URLSearchParams({ address }),
+    };
+
+    const { queryByText } = render(
+      <AccountProfilePage location={mockLocationSearchParam} />,
+    );
+
+    expect(queryByText('Edit Profile')).toBeInTheDocument();
+  });
+
+  it('does not render edit button if account connected but connected address not equal to query parameter `address`', async () => {
+    const address = '0x6B24aE0ABbeb67058D07b891aF415f288eA57Cc7';
+    mockGetAddress.mockReturnValue(address);
+    mockUseAccount.mockReturnValue({
+      address: '0x6B24aE0ABbeb67058D07b891aF415f288eA57000',
+      isConnected: true,
+    });
+
+    const mockLocationSearchParam = {
+      search: new URLSearchParams({ address }),
+    };
+
+    const { queryByText } = render(
+      <AccountProfilePage location={mockLocationSearchParam} />,
+    );
+
+    expect(queryByText('Edit Profile')).not.toBeInTheDocument();
+  });
+
+  it('does not render edit button if account is not connected', async () => {
+    const address = '0x6B24aE0ABbeb67058D07b891aF415f288eA57Cc7';
+    mockGetAddress.mockReturnValue(address);
+    mockUseAccount.mockReturnValue({
+      address: null,
+      isConnected: false,
+    });
+
+    const mockLocationSearchParam = {
+      search: new URLSearchParams({ address }),
+    };
+
+    const { queryByText } = render(
+      <AccountProfilePage location={mockLocationSearchParam} />,
+    );
+
     expect(queryByText('Edit Profile')).not.toBeInTheDocument();
   });
 

--- a/src/pages/account/index.tsx
+++ b/src/pages/account/index.tsx
@@ -3,6 +3,7 @@ import { Trans, t } from '@lingui/macro';
 import type { Hex } from '@metamask/utils';
 import { graphql, Link as GatsbyLink, withPrefix } from 'gatsby';
 import type { FunctionComponent } from 'react';
+import { useAccount } from 'wagmi';
 
 import banner from '../../assets/images/seo/home.png';
 import {
@@ -20,6 +21,7 @@ type AccountPageProps = {
 };
 
 const AccountPage: FunctionComponent<AccountPageProps> = ({ location }) => {
+  const { address: connectedAddress, isConnected } = useAccount();
   const params = new URLSearchParams(location.search);
   const address = parseAddress(params.get('address') as Hex);
   if (!address) {
@@ -27,19 +29,21 @@ const AccountPage: FunctionComponent<AccountPageProps> = ({ location }) => {
   }
 
   return (
-    <Box position="relative">
+    <Box position="relative" data-testid="account-info">
       <AccountProfileBanner />
       <Container maxWidth="container.xl" paddingTop="0" position="relative">
         <VStack mt="175" spacing={['10', null, '20']}>
           <AccountInfo address={address} />
           <Box position={['static', null, 'absolute']} right="5" top="100">
-            <Link
-              as={GatsbyLink}
-              variant="landing"
-              to={`/account/edit?address=${address}`}
-            >
-              <Trans>Edit Profile</Trans>
-            </Link>
+            {isConnected && address === connectedAddress && (
+              <Link
+                as={GatsbyLink}
+                variant="landing"
+                to={`/account/edit?address=${connectedAddress}`}
+              >
+                <Trans>Edit Profile</Trans>
+              </Link>
+            )}
           </Box>
           <Divider />
           <AccountProfileTabs />


### PR DESCRIPTION
## Description

The PR is to :

- Adding a edit button and visible only if account is connected and match the page address

- When connected, clicking on ConnectButton on the top bar will redirect to my account page

![image](https://github.com/MetaMask/permissionless-snaps-directory/assets/102275989/bb53eccc-ce4a-41d8-9bac-cb5bf3233126)

### Related ticket
#2 
Fixes #

### Type of change

- [ ] Chore
- [ ] Bug fix
- [X] New feature
- [ ] Documentation update
