### PR TITLE
feat: Change default value to 2000 ms

### DIFF
--- a/src/hooks/useToastMsg.test.ts
+++ b/src/hooks/useToastMsg.test.ts
@@ -146,7 +146,7 @@ describe('useToastMsg', () => {
       title: 'Error',
       description: 'Something went wrong',
       status: 'error',
-      duration: 200,
+      duration: 2000,
       isClosable: true,
     });
   });
@@ -166,7 +166,7 @@ describe('useToastMsg', () => {
       title: 'Info',
       description: 'Some information',
       status: 'info',
-      duration: 200,
+      duration: 2000,
       isClosable: true,
     });
   });
@@ -186,7 +186,7 @@ describe('useToastMsg', () => {
       title: 'Success',
       description: 'Some success',
       status: 'success',
-      duration: 200,
+      duration: 2000,
       isClosable: true,
     });
   });
@@ -206,7 +206,7 @@ describe('useToastMsg', () => {
       title: 'Warning',
       description: 'Some warning',
       status: 'warning',
-      duration: 200,
+      duration: 2000,
       isClosable: true,
     });
   });
@@ -226,7 +226,7 @@ describe('useToastMsg', () => {
       title: 'Loading',
       description: 'Some loading',
       status: 'loading',
-      duration: 200,
+      duration: 2000,
       isClosable: true,
     });
   });

--- a/src/hooks/useToastMsg.ts
+++ b/src/hooks/useToastMsg.ts
@@ -14,7 +14,7 @@ const useToastMsg = (params?: ToastProps) => {
   const showErrorMsg = ({
     title,
     description,
-    duration = 200,
+    duration = 2000,
     isClosable = true,
   }: MessageParams) =>
     toast({
@@ -28,7 +28,7 @@ const useToastMsg = (params?: ToastProps) => {
   const showInfoMsg = ({
     title,
     description,
-    duration = 200,
+    duration = 2000,
     isClosable = true,
   }: MessageParams) =>
     toast({
@@ -42,7 +42,7 @@ const useToastMsg = (params?: ToastProps) => {
   const showSuccessMsg = ({
     title,
     description,
-    duration = 200,
+    duration = 2000,
     isClosable = true,
   }: MessageParams) =>
     toast({
@@ -56,7 +56,7 @@ const useToastMsg = (params?: ToastProps) => {
   const showWarningMsg = ({
     title,
     description,
-    duration = 200,
+    duration = 2000,
     isClosable = true,
   }: MessageParams) =>
     toast({
@@ -70,7 +70,7 @@ const useToastMsg = (params?: ToastProps) => {
   const showLoadingMsg = ({
     title,
     description,
-    duration = 200,
+    duration = 2000,
     isClosable = true,
   }: MessageParams) =>
     toast({


### PR DESCRIPTION
The previous commit have mistake to make the toast disappear too fast, this PR will set the timeout of toast to 2000 ms.

## Description

### Related ticket

Fixes #

### Type of change

- [ ] Chore
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
