### PR TITLE
fix: remove double act in test

### DIFF
--- a/src/components/CheckboxWithSlider.test.tsx
+++ b/src/components/CheckboxWithSlider.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
 
 import {
   CheckboxWithSlider,
@@ -29,11 +29,8 @@ const defaultProps: CheckboxWithSliderProps = {
 
 describe('CheckboxWithSlider', () => {
   it('renders CheckboxWithSlider component', async () => {
-    const { queryByText, queryByTestId } = await act(
-      async () =>
-        await act(() =>
-          render(<CheckboxWithSlider {...defaultProps}></CheckboxWithSlider>),
-        ),
+    const { queryByText, queryByTestId } = render(
+      <CheckboxWithSlider {...defaultProps}></CheckboxWithSlider>,
     );
 
     expect(queryByText('Test Checkbox')).toBeInTheDocument();

--- a/src/components/ConnectButton.test.tsx
+++ b/src/components/ConnectButton.test.tsx
@@ -46,7 +46,7 @@ describe('ConnectKitButton.Custom', () => {
 
     const button = getByText('Connect');
 
-    await act(async () => act(() => button.click()));
+    await act(async () => button.click());
 
     expect(showModelSpy).toHaveBeenCalledTimes(1);
     expect(navigate).toHaveBeenCalledTimes(0);
@@ -59,7 +59,7 @@ describe('ConnectKitButton.Custom', () => {
 
     const button = getByText('mock.ens.name');
 
-    await act(async () => act(() => button.click()));
+    await act(async () => button.click());
 
     expect(showModelSpy).toHaveBeenCalledTimes(0);
     expect(navigate).toHaveBeenCalledTimes(1);

--- a/src/components/ConnectButtonInner.test.tsx
+++ b/src/components/ConnectButtonInner.test.tsx
@@ -11,7 +11,7 @@ describe('ConnectButtonInner', () => {
     );
 
     const button = getByText('Connect');
-    await act(async () => act(() => button.click()));
+    await act(async () => button.click());
 
     expect(btnClick).toHaveBeenCalledTimes(1);
   });

--- a/src/components/InstallSnapButton.test.tsx
+++ b/src/components/InstallSnapButton.test.tsx
@@ -71,7 +71,7 @@ describe('InstallSnapButton', () => {
     );
 
     const button = getByText('Add to MetaMask');
-    await act(async () => act(() => button.click()));
+    await act(async () => button.click());
 
     // eslint-disable-next-line @typescript-eslint/unbound-method, no-restricted-globals
     expect(window.ethereum.request).toHaveBeenCalledWith({
@@ -103,7 +103,7 @@ describe('InstallSnapButton', () => {
     );
 
     const button = getByText('Add to MetaMask');
-    await act(async () => act(() => button.click()));
+    await act(async () => button.click());
 
     // eslint-disable-next-line @typescript-eslint/unbound-method, no-restricted-globals
     expect(window.ethereum.request).toHaveBeenCalledWith({

--- a/src/components/Layout.test.tsx
+++ b/src/components/Layout.test.tsx
@@ -12,15 +12,12 @@ describe('Layout', () => {
       fusejs: {},
     });
 
-    const { queryByText } = await act(
-      async () =>
-        await act(() =>
-          render(
-            <Layout>
-              <Text>Foo</Text>
-            </Layout>,
-          ),
-        ),
+    const { queryByText } = await act(async () =>
+      render(
+        <Layout>
+          <Text>Foo</Text>
+        </Layout>,
+      ),
     );
 
     expect(queryByText('Foo')).toBeInTheDocument();

--- a/src/features/account/AccountReport.test.tsx
+++ b/src/features/account/AccountReport.test.tsx
@@ -28,11 +28,7 @@ describe('AccountReport', () => {
       <AccountReport address={VALID_ACCOUNT_1} />,
     );
 
-    await act(async () =>
-      act(() => {
-        getByText('Report').click();
-      }),
-    );
+    await act(async () => getByText('Report').click());
 
     expect(queryByText('Report')).toBeInTheDocument();
     expect(queryByText('Scamming')).toBeInTheDocument();
@@ -52,11 +48,7 @@ describe('AccountReport', () => {
       <AccountReport address={VALID_ACCOUNT_1} />,
     );
 
-    await act(async () =>
-      act(() => {
-        getByText('Report').click();
-      }),
-    );
+    await act(async () => getByText('Report').click());
 
     expect(queryByText(VALID_ACCOUNT_1)).toBeInTheDocument();
   });
@@ -71,11 +63,7 @@ describe('AccountReport', () => {
       <AccountReport address={VALID_ACCOUNT_1} />,
     );
 
-    await act(async () =>
-      act(() => {
-        getByText('Report').click();
-      }),
-    );
+    await act(async () => getByText('Report').click());
 
     expect(queryByText('mock.ens.name')).toBeInTheDocument();
   });
@@ -90,18 +78,11 @@ describe('AccountReport', () => {
       <AccountReport address={VALID_ACCOUNT_1} />,
     );
 
-    await act(async () =>
-      act(() => {
-        getByText('Report').click();
-      }),
-    );
-
-    await act(async () =>
-      act(() => {
-        getByText('Scamming').click();
-        getByText('Sign to report').click();
-      }),
-    );
+    await act(async () => getByText('Report').click());
+    await act(async () => {
+      getByText('Scamming').click();
+      getByText('Sign to report').click();
+    });
 
     expect(queryByText('mock.ens.name')).not.toBeInTheDocument();
   });
@@ -116,15 +97,8 @@ describe('AccountReport', () => {
       <AccountReport address={VALID_ACCOUNT_1} />,
     );
 
-    await act(async () =>
-      act(() => {
-        getByText('Report').click();
-      }),
-    );
-
-    await act(async () => {
-      getByLabelText('Close').click();
-    });
+    await act(async () => getByText('Report').click());
+    await act(async () => getByLabelText('Close').click());
 
     expect(queryByText('mock.ens.name')).not.toBeInTheDocument();
   });

--- a/src/features/account/MoreOptionMenu.test.tsx
+++ b/src/features/account/MoreOptionMenu.test.tsx
@@ -27,11 +27,8 @@ describe('MoreOptionMenu', () => {
   const renderMenuWithStore = async () => {
     const store = createStore();
 
-    const { getByTestId, queryByText } = await act(
-      async () =>
-        await act(() =>
-          render(<MoreOptionMenu subjectAddress={VALID_ACCOUNT_2} />, store),
-        ),
+    const { getByTestId, queryByText } = await act(async () =>
+      render(<MoreOptionMenu subjectAddress={VALID_ACCOUNT_2} />, store),
     );
 
     const menuBtn = getByTestId('icon-menu-button');

--- a/src/features/account/components/AccountInfo.test.tsx
+++ b/src/features/account/components/AccountInfo.test.tsx
@@ -47,11 +47,8 @@ describe('AccountInfo', () => {
       isConnected: true,
     }));
 
-    const { queryByTestId, queryByText } = await act(
-      async () =>
-        await act(() =>
-          render(<AccountInfo address={VALID_ACCOUNT_1} />, store),
-        ),
+    const { queryByTestId, queryByText } = await act(async () =>
+      render(<AccountInfo address={VALID_ACCOUNT_1} />, store),
     );
 
     expect(queryByTestId('account-info-loading')).not.toBeInTheDocument();
@@ -70,11 +67,8 @@ describe('AccountInfo', () => {
       isConnected: true,
     }));
 
-    const { queryByTestId } = await act(
-      async () =>
-        await act(() =>
-          render(<AccountInfo address={VALID_ACCOUNT_1} />, store),
-        ),
+    const { queryByTestId } = await act(async () =>
+      render(<AccountInfo address={VALID_ACCOUNT_1} />, store),
     );
 
     expect(queryByTestId('account-info-loading')).toBeInTheDocument();
@@ -90,11 +84,8 @@ describe('AccountInfo', () => {
       isConnected: true,
     }));
 
-    const { queryByText } = await act(
-      async () =>
-        await act(() =>
-          render(<AccountInfo address={VALID_ACCOUNT_1} />, store),
-        ),
+    const { queryByText } = await act(async () =>
+      render(<AccountInfo address={VALID_ACCOUNT_1} />, store),
     );
     expect(queryByText('0x6B24a...57Cc7')).toBeInTheDocument();
   });
@@ -109,11 +100,8 @@ describe('AccountInfo', () => {
       isConnected: false,
     }));
 
-    const { queryByTestId } = await act(
-      async () =>
-        await act(() =>
-          render(<AccountInfo address={VALID_ACCOUNT_1} />, store),
-        ),
+    const { queryByTestId } = await act(async () =>
+      render(<AccountInfo address={VALID_ACCOUNT_1} />, store),
     );
 
     expect(queryByTestId('icon-menu-button')).not.toBeInTheDocument();

--- a/src/features/account/components/modals/AccountReportModal.test.tsx
+++ b/src/features/account/components/modals/AccountReportModal.test.tsx
@@ -40,12 +40,10 @@ describe('AccountReportModal', () => {
       />,
     );
 
-    await act(async () =>
-      act(() => {
-        getByText('label 1').click();
-        getByText('Sign to report').click();
-      }),
-    );
+    await act(async () => {
+      getByText('label 1').click();
+      getByText('Sign to report').click();
+    });
 
     expect(onSign).toHaveBeenCalledWith(['label 1']);
   });

--- a/src/features/notifications/components/NotificationsList.test.tsx
+++ b/src/features/notifications/components/NotificationsList.test.tsx
@@ -43,16 +43,13 @@ describe('NotificationsList', () => {
       },
     });
 
-    const { queryByText } = await act(
-      async () =>
-        await act(() =>
-          render(
-            <Menu>
-              <NotificationsList />
-            </Menu>,
-            store,
-          ),
-        ),
+    const { queryByText } = await act(async () =>
+      render(
+        <Menu>
+          <NotificationsList />
+        </Menu>,
+        store,
+      ),
     );
 
     expect(queryByText('No notifications')).not.toBeInTheDocument();

--- a/src/features/snaps/Snaps.test.tsx
+++ b/src/features/snaps/Snaps.test.tsx
@@ -14,18 +14,15 @@ describe('Snaps', () => {
   it('renders the no Snaps screen when there are no snaps', async () => {
     // Double `act`, because otherwise we get a warning about an update
     // happening outside of an `act()` call.
-    const { queryByTestId } = await act(
-      async () =>
-        await act(() =>
-          render(
-            <Snaps />,
-            createStore({
-              snaps: {
-                snaps: [],
-              },
-            }),
-          ),
-        ),
+    const { queryByTestId } = await act(async () =>
+      render(
+        <Snaps />,
+        createStore({
+          snaps: {
+            snaps: [],
+          },
+        }),
+      ),
     );
 
     expect(queryByTestId('no-snaps')).toBeInTheDocument();
@@ -34,21 +31,18 @@ describe('Snaps', () => {
   it('renders the Snaps', async () => {
     // Double `act`, because otherwise we get a warning about an update
     // happening outside of an `act()` call.
-    const { queryByText } = await act(
-      async () =>
-        await act(() =>
-          render(
-            <Snaps />,
-            createStore({
-              snaps: {
-                snaps: [
-                  getMockSnap({ id: 'foo', name: 'Foo Snap' }).snap,
-                  getMockSnap({ id: 'bar', name: 'Bar Snap' }).snap,
-                ],
-              },
-            }),
-          ),
-        ),
+    const { queryByText } = await act(async () =>
+      render(
+        <Snaps />,
+        createStore({
+          snaps: {
+            snaps: [
+              getMockSnap({ id: 'foo', name: 'Foo Snap' }).snap,
+              getMockSnap({ id: 'bar', name: 'Bar Snap' }).snap,
+            ],
+          },
+        }),
+      ),
     );
 
     expect(queryByText('Foo Snap')).toBeInTheDocument();

--- a/src/pages/explore.test.tsx
+++ b/src/pages/explore.test.tsx
@@ -71,7 +71,7 @@ describe('Explore page', () => {
 
     const button = getByText('See All');
 
-    await act(async () => act(() => button.click()));
+    await act(async () => button.click());
 
     expect(queryByText('Foo Snap')).toBeInTheDocument();
     expect(queryByText('Bar Snap')).toBeInTheDocument();


### PR DESCRIPTION
## Description

This PR is to fix the redundant act in the test case

- we dont need double act for click action
- we dont need double act for render component with async redux store
- we dont act for render component without redux store

### Related ticket

Fixes #

### Type of change

- [X] Chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
