### PR TITLE
fix: report snap version use checksum

### DIFF
--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -16,11 +16,14 @@ import type { GatsbyNode, NodeInput } from 'gatsby';
 import { createFileNodeFromBuffer } from 'gatsby-source-filesystem';
 import type { RequestInfo, RequestInit } from 'node-fetch';
 import fetch from 'node-fetch';
-import { fetchBuilder, FileSystemCache } from 'node-fetch-cache';
+import { FileSystemCache, fetchBuilder } from 'node-fetch-cache';
 import path from 'path';
 
 import type { Fields } from './src/utils';
-import { getLatestSnapVersion } from './src/utils';
+import {
+  getLatestSnapVersion,
+  getLatestSnapVersionChecksum,
+} from './src/utils';
 import {
   generateCategoryImage,
   generateInstalledImage,
@@ -44,6 +47,7 @@ type SnapNode = NodeInput & {
   slug: string;
   latestVersion: string;
   icon?: string | undefined;
+  latestChecksum: string;
 };
 
 // eslint-disable-next-line no-restricted-globals
@@ -162,6 +166,8 @@ export const sourceNodes: GatsbyNode[`sourceNodes`] = async ({
 
   for (const snap of verifiedSnaps) {
     const latestVersion = getLatestSnapVersion(snap);
+    const latestChecksum = getLatestSnapVersionChecksum(snap, latestVersion);
+
     const location = detectSnapLocation(snap.id, {
       versionRange: latestVersion as any,
       fetch: customFetch as any,
@@ -222,6 +228,7 @@ export const sourceNodes: GatsbyNode[`sourceNodes`] = async ({
       icon,
       downloads,
       lastUpdated,
+      latestChecksum,
     };
 
     const node: SnapNode = {

--- a/src/components/SnapsProvider.tsx
+++ b/src/components/SnapsProvider.tsx
@@ -32,6 +32,7 @@ export const SnapsProvider: FunctionComponent<SnapsProviderProps> = ({
           summary
           icon
           latestVersion
+          latestChecksum
           category
           gatsbyPath(filePath: "/snap/{Snap.location}/{Snap.slug}")
           downloads

--- a/src/features/snap/components/Metadata.tsx
+++ b/src/features/snap/components/Metadata.tsx
@@ -18,6 +18,7 @@ export type MetadataProps = {
     | 'snapId'
     | 'description'
     | 'latestVersion'
+    | 'latestChecksum'
     | 'website'
     | 'onboard'
     | 'category'

--- a/src/features/snap/components/ReportSnap.test.tsx
+++ b/src/features/snap/components/ReportSnap.test.tsx
@@ -2,7 +2,11 @@ import { act } from '@testing-library/react';
 
 import { ReportSnap } from './ReportSnap';
 import { useVerifiableCredential } from '../../../hooks';
-import { VALID_ACCOUNT_1, render } from '../../../utils/test-utils';
+import {
+  SNAP_SHASUM_1,
+  VALID_ACCOUNT_1,
+  render,
+} from '../../../utils/test-utils';
 
 jest.mock('../../../hooks/useVerifiableCredential', () => ({
   ...jest.requireActual('../../../hooks/useVerifiableCredential'),
@@ -26,7 +30,7 @@ describe('ReportSnap', () => {
     const { queryByText } = render(
       <ReportSnap
         snapName="Snap1"
-        versionChecksum="mockv1checksum"
+        versionChecksum={SNAP_SHASUM_1}
         address={VALID_ACCOUNT_1}
       />,
     );
@@ -43,7 +47,7 @@ describe('ReportSnap', () => {
     const { queryByText, getByText } = render(
       <ReportSnap
         snapName="Snap1"
-        versionChecksum="mockv1checksum"
+        versionChecksum={SNAP_SHASUM_1}
         address={VALID_ACCOUNT_1}
       />,
     );
@@ -71,7 +75,7 @@ describe('ReportSnap', () => {
     const { queryByText, getByText } = render(
       <ReportSnap
         snapName="Snap1"
-        versionChecksum="mockv1checksum"
+        versionChecksum={SNAP_SHASUM_1}
         address={VALID_ACCOUNT_1}
       />,
     );
@@ -95,7 +99,7 @@ describe('ReportSnap', () => {
     const { queryByText, getByText, getByLabelText } = render(
       <ReportSnap
         snapName="Snap1"
-        versionChecksum="mockv1checksum"
+        versionChecksum={SNAP_SHASUM_1}
         address={VALID_ACCOUNT_1}
       />,
     );
@@ -123,7 +127,7 @@ describe('ReportSnap', () => {
     const { queryByText, getByText } = render(
       <ReportSnap
         snapName="Snap1"
-        versionChecksum="mockv1checksum"
+        versionChecksum={SNAP_SHASUM_1}
         address={VALID_ACCOUNT_1}
       />,
     );

--- a/src/features/snap/components/ReportSnap.test.tsx
+++ b/src/features/snap/components/ReportSnap.test.tsx
@@ -26,7 +26,7 @@ describe('ReportSnap', () => {
     const { queryByText } = render(
       <ReportSnap
         snapName="Snap1"
-        snapId="Snap1ID"
+        versionChecksum="mockv1checksum"
         address={VALID_ACCOUNT_1}
       />,
     );
@@ -43,7 +43,7 @@ describe('ReportSnap', () => {
     const { queryByText, getByText } = render(
       <ReportSnap
         snapName="Snap1"
-        snapId="Snap1ID"
+        versionChecksum="mockv1checksum"
         address={VALID_ACCOUNT_1}
       />,
     );
@@ -71,7 +71,7 @@ describe('ReportSnap', () => {
     const { queryByText, getByText } = render(
       <ReportSnap
         snapName="Snap1"
-        snapId="Snap1ID"
+        versionChecksum="mockv1checksum"
         address={VALID_ACCOUNT_1}
       />,
     );
@@ -95,7 +95,7 @@ describe('ReportSnap', () => {
     const { queryByText, getByText, getByLabelText } = render(
       <ReportSnap
         snapName="Snap1"
-        snapId="Snap1ID"
+        versionChecksum="mockv1checksum"
         address={VALID_ACCOUNT_1}
       />,
     );
@@ -123,7 +123,7 @@ describe('ReportSnap', () => {
     const { queryByText, getByText } = render(
       <ReportSnap
         snapName="Snap1"
-        snapId="Snap1ID"
+        versionChecksum="mockv1checksum"
         address={VALID_ACCOUNT_1}
       />,
     );

--- a/src/features/snap/components/ReportSnap.test.tsx
+++ b/src/features/snap/components/ReportSnap.test.tsx
@@ -30,7 +30,7 @@ describe('ReportSnap', () => {
     const { queryByText } = render(
       <ReportSnap
         snapName="Snap1"
-        versionChecksum={SNAP_SHASUM_1}
+        snapChecksum={SNAP_SHASUM_1}
         address={VALID_ACCOUNT_1}
       />,
     );
@@ -47,7 +47,7 @@ describe('ReportSnap', () => {
     const { queryByText, getByText } = render(
       <ReportSnap
         snapName="Snap1"
-        versionChecksum={SNAP_SHASUM_1}
+        snapChecksum={SNAP_SHASUM_1}
         address={VALID_ACCOUNT_1}
       />,
     );
@@ -75,7 +75,7 @@ describe('ReportSnap', () => {
     const { queryByText, getByText } = render(
       <ReportSnap
         snapName="Snap1"
-        versionChecksum={SNAP_SHASUM_1}
+        snapChecksum={SNAP_SHASUM_1}
         address={VALID_ACCOUNT_1}
       />,
     );
@@ -99,7 +99,7 @@ describe('ReportSnap', () => {
     const { queryByText, getByText, getByLabelText } = render(
       <ReportSnap
         snapName="Snap1"
-        versionChecksum={SNAP_SHASUM_1}
+        snapChecksum={SNAP_SHASUM_1}
         address={VALID_ACCOUNT_1}
       />,
     );
@@ -127,7 +127,7 @@ describe('ReportSnap', () => {
     const { queryByText, getByText } = render(
       <ReportSnap
         snapName="Snap1"
-        versionChecksum={SNAP_SHASUM_1}
+        snapChecksum={SNAP_SHASUM_1}
         address={VALID_ACCOUNT_1}
       />,
     );

--- a/src/features/snap/components/ReportSnap.tsx
+++ b/src/features/snap/components/ReportSnap.tsx
@@ -16,7 +16,7 @@ type ReportSnapProps = {
 
 export const ReportSnap: FunctionComponent<ReportSnapProps> = ({
   address,
-  versionChecksum,
+  snapChecksum,
   snapName,
 }) => {
   const [showModal, setShowModal] = useState(false);

--- a/src/features/snap/components/ReportSnap.tsx
+++ b/src/features/snap/components/ReportSnap.tsx
@@ -10,7 +10,7 @@ import useToastMsg from '../../../hooks/useToastMsg';
 
 type ReportSnapProps = {
   address: Hex;
-  versionChecksum: string;
+  snapChecksum: string;
   snapName: string;
 };
 
@@ -34,7 +34,7 @@ export const ReportSnap: FunctionComponent<ReportSnapProps> = ({
   const onSign = async (selected: string[]) => {
     const VC = snapVCBuilder.buildDisputedPayload(
       address,
-      versionChecksum,
+      snapChecksum,
       selected,
     );
 

--- a/src/features/snap/components/ReportSnap.tsx
+++ b/src/features/snap/components/ReportSnap.tsx
@@ -10,13 +10,13 @@ import useToastMsg from '../../../hooks/useToastMsg';
 
 type ReportSnapProps = {
   address: Hex;
-  snapId: string;
+  versionChecksum: string;
   snapName: string;
 };
 
 export const ReportSnap: FunctionComponent<ReportSnapProps> = ({
   address,
-  snapId,
+  versionChecksum,
   snapName,
 }) => {
   const [showModal, setShowModal] = useState(false);
@@ -32,7 +32,11 @@ export const ReportSnap: FunctionComponent<ReportSnapProps> = ({
   const options = [t`Scam`, t`Vulnerable`];
 
   const onSign = async (selected: string[]) => {
-    const VC = snapVCBuilder.buildDisputedPayload(address, snapId, selected);
+    const VC = snapVCBuilder.buildDisputedPayload(
+      address,
+      versionChecksum,
+      selected,
+    );
 
     const signature = await signMessage(VC);
     if (signature) {

--- a/src/features/snaps/store.ts
+++ b/src/features/snaps/store.ts
@@ -21,6 +21,7 @@ export type Snap = Fields<
   | 'latestVersion'
   | 'downloads'
   | 'lastUpdated'
+  | 'latestChecksum'
 >;
 
 export type SnapsState = {

--- a/src/pages/snap/{Snap.location}/{Snap.slug}.tsx
+++ b/src/pages/snap/{Snap.location}/{Snap.slug}.tsx
@@ -26,6 +26,7 @@ type SnapPageProps = {
       | 'snapId'
       | 'description'
       | 'latestVersion'
+      | 'latestChecksum'
       | 'website'
       | 'onboard'
       | 'category'
@@ -47,6 +48,7 @@ const SnapPage: FunctionComponent<SnapPageProps> = ({ data }) => {
     onboard,
     description,
     latestVersion,
+    latestChecksum,
     category,
   } = data.snap;
 
@@ -80,7 +82,11 @@ const SnapPage: FunctionComponent<SnapPageProps> = ({ data }) => {
           <Authorship name={name} icon={icon} snapId={snapId} />
           <Flex alignItems="center" gap="4" width={['100%', null, 'auto']}>
             {isConnected && address && (
-              <ReportSnap snapName={name} snapId={snapId} address={address} />
+              <ReportSnap
+                snapName={name}
+                snapId={latestChecksum}
+                address={address}
+              />
             )}
             {!onboard && (
               <InstallSnapButton
@@ -187,6 +193,7 @@ export const query = graphql`
         trusted
       }
       latestVersion
+      latestChecksum
       website
       onboard
       category

--- a/src/pages/snap/{Snap.location}/{Snap.slug}.tsx
+++ b/src/pages/snap/{Snap.location}/{Snap.slug}.tsx
@@ -84,7 +84,7 @@ const SnapPage: FunctionComponent<SnapPageProps> = ({ data }) => {
             {isConnected && address && (
               <ReportSnap
                 snapName={name}
-                versionChecksum={latestChecksum}
+                snapChecksum={latestChecksum}
                 address={address}
               />
             )}

--- a/src/pages/snap/{Snap.location}/{Snap.slug}.tsx
+++ b/src/pages/snap/{Snap.location}/{Snap.slug}.tsx
@@ -84,7 +84,7 @@ const SnapPage: FunctionComponent<SnapPageProps> = ({ data }) => {
             {isConnected && address && (
               <ReportSnap
                 snapName={name}
-                snapId={latestChecksum}
+                versionChecksum={latestChecksum}
                 address={address}
               />
             )}

--- a/src/utils/snaps.test.ts
+++ b/src/utils/snaps.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach } from '@jest/globals';
 import type { VerifiedSnap } from './snaps';
 import {
   getLatestSnapVersion,
+  getLatestSnapVersionChecksum,
   getMetaMaskProvider,
   getSnapsProvider,
   hasSnapsSupport,
@@ -293,5 +294,37 @@ describe('getLatestSnapVersion', () => {
     expect(() => getLatestSnapVersion(snap)).toThrow(
       'No latest version found for Snap: foo-snap.',
     );
+  });
+
+  it('returns latest version checksum', () => {
+    const snap: VerifiedSnap = {
+      versions: {
+        // @ts-expect-error - Technically not a valid version.
+        '1.0.0': {
+          checksum: 'foo',
+        },
+        '2.0.0': {
+          checksum: 'bar',
+        },
+      },
+    };
+
+    expect(getLatestSnapVersionChecksum(snap, '2.0.0')).toBe('bar');
+  });
+
+  it('returns empty string if version does not exist', () => {
+    const snap: VerifiedSnap = {
+      versions: {
+        // @ts-expect-error - Technically not a valid version.
+        '1.0.0': {
+          checksum: 'foo',
+        },
+        '2.0.0': {
+          checksum: 'bar',
+        },
+      },
+    };
+
+    expect(getLatestSnapVersionChecksum(snap, '3.0.0')).toBe('');
   });
 });

--- a/src/utils/snaps.test.ts
+++ b/src/utils/snaps.test.ts
@@ -316,8 +316,9 @@ describe('getLatestSnapVersion', () => {
     expect(getLatestSnapVersionChecksum(snap, '2.0.0')).toBe(SNAP_SHASUM_2);
   });
 
-  it('returns empty string if version does not exist', () => {
+  it('throws error if version does not exist', () => {
     const snap: VerifiedSnap = {
+      id: 'foo-snap',
       versions: {
         // @ts-expect-error - Technically not a valid version.
         '1.0.0': {
@@ -329,6 +330,8 @@ describe('getLatestSnapVersion', () => {
       },
     };
 
-    expect(getLatestSnapVersionChecksum(snap, '3.0.0')).toBe('');
+    expect(() => getLatestSnapVersionChecksum(snap, '3.0.0')).toThrow(
+      'Snap:foo-snap version data does not exist for the version 3.0.0',
+    );
   });
 });

--- a/src/utils/snaps.test.ts
+++ b/src/utils/snaps.test.ts
@@ -9,7 +9,11 @@ import {
   hasSnapsSupport,
   isMetaMaskProvider,
 } from './snaps';
-import { getRequestMethodMock } from './test-utils';
+import {
+  SNAP_SHASUM_1,
+  SNAP_SHASUM_2,
+  getRequestMethodMock,
+} from './test-utils';
 
 describe('hasSnapsSupport', () => {
   it('returns `true` if the provider supports Snaps', async () => {
@@ -301,15 +305,15 @@ describe('getLatestSnapVersion', () => {
       versions: {
         // @ts-expect-error - Technically not a valid version.
         '1.0.0': {
-          checksum: 'foo',
+          checksum: SNAP_SHASUM_1,
         },
         '2.0.0': {
-          checksum: 'bar',
+          checksum: SNAP_SHASUM_2,
         },
       },
     };
 
-    expect(getLatestSnapVersionChecksum(snap, '2.0.0')).toBe('bar');
+    expect(getLatestSnapVersionChecksum(snap, '2.0.0')).toBe(SNAP_SHASUM_2);
   });
 
   it('returns empty string if version does not exist', () => {
@@ -317,10 +321,10 @@ describe('getLatestSnapVersion', () => {
       versions: {
         // @ts-expect-error - Technically not a valid version.
         '1.0.0': {
-          checksum: 'foo',
+          checksum: SNAP_SHASUM_1,
         },
         '2.0.0': {
-          checksum: 'bar',
+          checksum: SNAP_SHASUM_2,
         },
       },
     };

--- a/src/utils/snaps.ts
+++ b/src/utils/snaps.ts
@@ -141,3 +141,22 @@ export function getLatestSnapVersion(snap: VerifiedSnap) {
 
   return latest;
 }
+
+/**
+ * Get checksum of the latest version of the given Snap.
+ *
+ * @param snap - The Snap to get the latest version for.
+ * @param latestVersion - The latest version of the Snap.
+ * @returns The checksum value of latest version of the Snap.
+ */
+export function getLatestSnapVersionChecksum(
+  snap: VerifiedSnap,
+  latestVersion: string,
+) {
+  const { versions } = snap;
+
+  if (!versions[latestVersion]) {
+    return '';
+  }
+  return versions[latestVersion].checksum;
+}

--- a/src/utils/snaps.ts
+++ b/src/utils/snaps.ts
@@ -148,6 +148,7 @@ export function getLatestSnapVersion(snap: VerifiedSnap) {
  * @param snap - The Snap to get the latest version for.
  * @param latestVersion - The latest version of the Snap.
  * @returns The checksum value of latest version of the Snap.
+ * @throws If the latest version doesn't exist in the Snap.
  */
 export function getLatestSnapVersionChecksum(
   snap: VerifiedSnap,
@@ -156,7 +157,9 @@ export function getLatestSnapVersionChecksum(
   const { versions } = snap;
 
   if (!versions[latestVersion]) {
-    return '';
+    throw new Error(
+      `Snap:${snap.id} version data does not exist for the version ${latestVersion}`,
+    );
   }
   return versions[latestVersion].checksum;
 }

--- a/src/utils/test-utils/constants.ts
+++ b/src/utils/test-utils/constants.ts
@@ -4,3 +4,4 @@ export const VALID_ACCOUNT_2 = '0x7B17936E2a44C1fFef392d13e490fc8426d3329e';
 export const INVALID_ADDRESS = '0x123123123';
 
 export const SNAP_SHASUM_1 = 'ALj0YMDz4JNchPJfreWErQx/GOh4FMWWy1o1rCq7sQQ=';
+export const SNAP_SHASUM_2 = 'CaO1hCMftzS8NR608xuMe/kjXG7k+YtG6eq1Q6jAx7Q=';

--- a/src/utils/test-utils/queries.ts
+++ b/src/utils/test-utils/queries.ts
@@ -53,6 +53,7 @@ export type MockSnap = Fields<
   | 'description'
   | 'summary'
   | 'latestVersion'
+  | 'latestChecksum'
   | 'website'
   | 'onboard'
   | 'category'
@@ -74,6 +75,7 @@ export type GetMockSnapArgs = {
   description?: Fields<Queries.SnapDescription, 'description' | 'trusted'>;
   summary?: string;
   latestVersion?: string;
+  latestChecksum?: string;
   website?: string;
   onboard?: boolean;
   category?: RegistrySnapCategory | undefined;
@@ -111,6 +113,7 @@ export type GetMockSnapArgs = {
  * @param args.gatsbyPath - The Gatsby path.
  * @param args.downloads - The number of downloads.
  * @param args.lastUpdated - A unix timestamp of the last update to the snap.
+ * @param args.latestChecksum - The checksum value of latest version of the Snap.
  * @returns The mock snap data.
  */
 export function getMockSnap({
@@ -124,6 +127,7 @@ export function getMockSnap({
   },
   summary = 'Summary',
   latestVersion = '1.0.0',
+  latestChecksum = 'foo',
   website = 'https://example.com',
   onboard = false,
   category = RegistrySnapCategory.TransactionInsights,
@@ -159,6 +163,7 @@ export function getMockSnap({
       description,
       summary,
       latestVersion,
+      latestChecksum,
       website,
       onboard,
       category,

--- a/src/utils/test-utils/queries.ts
+++ b/src/utils/test-utils/queries.ts
@@ -1,3 +1,4 @@
+import { SNAP_SHASUM_1 } from './constants';
 import { RegistrySnapCategory } from '../../constants';
 import type { Fields } from '../snaps';
 
@@ -127,7 +128,7 @@ export function getMockSnap({
   },
   summary = 'Summary',
   latestVersion = '1.0.0',
-  latestChecksum = 'foo',
+  latestChecksum = SNAP_SHASUM_1,
   website = 'https://example.com',
   onboard = false,
   category = RegistrySnapCategory.TransactionInsights,

--- a/src/utils/verifiable-credential/snapVC.ts
+++ b/src/utils/verifiable-credential/snapVC.ts
@@ -64,7 +64,6 @@ export class SnapVerifiableCredential extends BaseVerifiableCredential {
   };
 
   protected getSubjectDid(versionChecksum: string): SnapDid {
-    // TODO how to check verify the checksum is shasum?? they only will be same if they all use SHA algorithm
     return `snap://${versionChecksum}`;
   }
 

--- a/src/utils/verifiable-credential/snapVC.ts
+++ b/src/utils/verifiable-credential/snapVC.ts
@@ -63,17 +63,17 @@ export class SnapVerifiableCredential extends BaseVerifiableCredential {
     ],
   };
 
-  protected getSubjectDid(versionChecksum: string): SnapDid {
-    return `snap://${versionChecksum}`;
+  protected getSubjectDid(snapChecksum: string): SnapDid {
+    return `snap://${snapChecksum}`;
   }
 
   protected getCredentialSubject(
-    versionChecksum: string,
+    snapChecksum: string,
     status: SnapCurrentStatus,
     statusReason: StatusReason,
   ): SnapCredentialSubject {
     return {
-      id: this.getSubjectDid(versionChecksum),
+      id: this.getSubjectDid(snapChecksum),
       currentStatus: status,
       statusReason,
     };
@@ -81,7 +81,7 @@ export class SnapVerifiableCredential extends BaseVerifiableCredential {
 
   buildEndosedPayload(
     issuerAddress: Hex,
-    versionChecksum: string,
+    snapChecksum: string,
     reason: string[],
   ) {
     const statusReason = {
@@ -91,7 +91,7 @@ export class SnapVerifiableCredential extends BaseVerifiableCredential {
     return this.buildSignPayload(
       issuerAddress,
       this.getCredentialSubject(
-        versionChecksum,
+        snapChecksum,
         SnapCurrentStatus.Endorsed,
         statusReason,
       ),
@@ -100,7 +100,7 @@ export class SnapVerifiableCredential extends BaseVerifiableCredential {
 
   buildDisputedPayload(
     issuerAddress: Hex,
-    versionChecksum: string,
+    snapChecksum: string,
     reason: string[],
   ) {
     const statusReason = {
@@ -110,7 +110,7 @@ export class SnapVerifiableCredential extends BaseVerifiableCredential {
     return this.buildSignPayload(
       issuerAddress,
       this.getCredentialSubject(
-        versionChecksum,
+        snapChecksum,
         SnapCurrentStatus.Disputed,
         statusReason,
       ),

--- a/src/utils/verifiable-credential/snapVC.ts
+++ b/src/utils/verifiable-credential/snapVC.ts
@@ -63,23 +63,28 @@ export class SnapVerifiableCredential extends BaseVerifiableCredential {
     ],
   };
 
-  protected getSubjectDid(snapId: string): SnapDid {
-    return `snap://${snapId}`;
+  protected getSubjectDid(versionChecksum: string): SnapDid {
+    // TODO how to check verify the checksum is shasum?? they only will be same if they all use SHA algorithm
+    return `snap://${versionChecksum}`;
   }
 
   protected getCredentialSubject(
-    subjectId: string,
+    versionChecksum: string,
     status: SnapCurrentStatus,
     statusReason: StatusReason,
   ): SnapCredentialSubject {
     return {
-      id: this.getSubjectDid(subjectId),
+      id: this.getSubjectDid(versionChecksum),
       currentStatus: status,
       statusReason,
     };
   }
 
-  buildEndosedPayload(issuerAddress: Hex, subjectId: string, reason: string[]) {
+  buildEndosedPayload(
+    issuerAddress: Hex,
+    versionChecksum: string,
+    reason: string[],
+  ) {
     const statusReason = {
       type: SnapStatusReasonType.Endorse,
       value: reason,
@@ -87,7 +92,7 @@ export class SnapVerifiableCredential extends BaseVerifiableCredential {
     return this.buildSignPayload(
       issuerAddress,
       this.getCredentialSubject(
-        subjectId,
+        versionChecksum,
         SnapCurrentStatus.Endorsed,
         statusReason,
       ),
@@ -96,7 +101,7 @@ export class SnapVerifiableCredential extends BaseVerifiableCredential {
 
   buildDisputedPayload(
     issuerAddress: Hex,
-    subjectId: string,
+    versionChecksum: string,
     reason: string[],
   ) {
     const statusReason = {
@@ -106,7 +111,7 @@ export class SnapVerifiableCredential extends BaseVerifiableCredential {
     return this.buildSignPayload(
       issuerAddress,
       this.getCredentialSubject(
-        subjectId,
+        versionChecksum,
         SnapCurrentStatus.Disputed,
         statusReason,
       ),


### PR DESCRIPTION
## Description

This PR will change will use correct CredentialSubject.id in the payload, basically the format of CredentialSubject id for snap should be .

```
snap://<shasum> of the snaps version
```
The shasum in this version will snap latest version of checksum.

Following changes have been made:
- Change Snaps type to support `latestChecksum` is latest version checksum value
- Change SnapsProvider to include `latestChecksum`
- in `Gatsby-node.ts`, change fetch latest version checksum from verifiedSnap registory
- Modify `{snap.slug}' page graphQL query to include fetch `latestChecksum`
- Change `snapVC` to build SubjectDid using `versionChecksum`
- change component `ReportSnap` to use `latestChecksum` as `versionChecksum`

### Related ticket

Fixes #

### Type of change

- [ ] Chore
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
