### PR TITLE
feat: change all existing components to use useSignErrorHandler

### DIFF
--- a/src/features/account/AccountReport.test.tsx
+++ b/src/features/account/AccountReport.test.tsx
@@ -4,10 +4,7 @@ import { useEnsName } from 'wagmi';
 
 import { AccountReport } from './AccountReport';
 import type { VCSignError } from '../../hooks/useVerifiableCredential';
-import {
-  useVerifiableCredential,
-  VCSignErrorType,
-} from '../../hooks/useVerifiableCredential';
+import { useVerifiableCredential } from '../../hooks/useVerifiableCredential';
 import { trimAddress } from '../../utils';
 import {
   render,
@@ -229,103 +226,6 @@ describe('AccountReport', () => {
       expect(signMessageSpy).toHaveBeenCalled();
       expect(buildReportAccountTrustSpy).toHaveBeenCalled();
       expect(getSignedAssertionSpy).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('with signError', () => {
-    it('shows `Failed to sign the message` toast message when signError is of type `SignError`', async () => {
-      buildEnsNameMock('mock.ens.name');
-      const { toastSpy } = buildToastSpy();
-      buildUseVerifiableCredentialMock({
-        type: VCSignErrorType.SignError,
-        message: 'sign error',
-      });
-
-      await act(async () =>
-        render(
-          <AccountReport
-            address={VALID_ACCOUNT_1}
-            connectedAddress={VALID_ACCOUNT_2}
-          />,
-        ),
-      );
-
-      expect(toastSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          title: 'Failed to sign the message',
-          description: 'sign error',
-        }),
-      );
-    });
-
-    it('shows `Failed to verify signature` toast message when signError is of type `VerifyError`', async () => {
-      buildEnsNameMock('mock.ens.name');
-      const { toastSpy } = buildToastSpy();
-      buildUseVerifiableCredentialMock({ type: VCSignErrorType.VerifyError });
-
-      await act(async () =>
-        render(
-          <AccountReport
-            address={VALID_ACCOUNT_1}
-            connectedAddress={VALID_ACCOUNT_2}
-          />,
-        ),
-      );
-
-      expect(toastSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          title: 'Failed to verify signature',
-          description: 'Your signature is invalid',
-        }),
-      );
-    });
-
-    it('shows `Invalid Signature` toast message when signError is of type `SignError`', async () => {
-      buildEnsNameMock('mock.ens.name');
-      const { toastSpy } = buildToastSpy();
-      buildUseVerifiableCredentialMock({
-        type: VCSignErrorType.VerifyFailed,
-        message: 'invalid signature',
-      });
-
-      await act(async () =>
-        render(
-          <AccountReport
-            address={VALID_ACCOUNT_1}
-            connectedAddress={VALID_ACCOUNT_2}
-          />,
-        ),
-      );
-
-      expect(toastSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          title: 'Invalid Signature',
-          description: 'invalid signature',
-        }),
-      );
-    });
-
-    it('shows `Failed to sign the message` toast message when signError is unknown', async () => {
-      buildEnsNameMock('mock.ens.name');
-      const { toastSpy } = buildToastSpy();
-      // @ts-expect-error - Invalid error.
-      buildUseVerifiableCredentialMock({ type: 'unknown' });
-
-      await act(async () =>
-        render(
-          <AccountReport
-            address={VALID_ACCOUNT_1}
-            connectedAddress={VALID_ACCOUNT_2}
-          />,
-        ),
-      );
-
-      expect(toastSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          title: 'Failed to sign the message',
-          description: 'Unknown error',
-        }),
-      );
     });
   });
 });

--- a/src/features/account/AccountReport.tsx
+++ b/src/features/account/AccountReport.tsx
@@ -1,11 +1,12 @@
 import { t } from '@lingui/macro';
 import type { Hex } from '@metamask/utils';
-import { useState, type FunctionComponent, useMemo, useEffect } from 'react';
+import { useMemo, useState, type FunctionComponent } from 'react';
 import { useEnsName } from 'wagmi';
 
 import { AccountReportModal } from './components';
 import { ReportButton } from '../../components';
-import { VCSignErrorType, useVerifiableCredential } from '../../hooks';
+import { useVerifiableCredential } from '../../hooks';
+import { useSignErrorHandler } from '../../hooks/useSignErrorHandler';
 import useToastMsg from '../../hooks/useToastMsg';
 import { trimAddress } from '../../utils';
 
@@ -22,10 +23,12 @@ export const AccountReport: FunctionComponent<AccountReportProps> = ({
     address,
   });
 
-  const { showErrorMsg, showSuccessMsg } = useToastMsg();
+  const { showSuccessMsg } = useToastMsg();
 
   const { signMessage, signError, accountVCBuilder } =
     useVerifiableCredential();
+
+  useSignErrorHandler(signError);
 
   const trimedAddress = useMemo(() => trimAddress(address), [address]);
 
@@ -66,34 +69,6 @@ export const AccountReport: FunctionComponent<AccountReportProps> = ({
       setShowModal(false);
     }
   };
-
-  useEffect(() => {
-    if (signError) {
-      if (signError.type === VCSignErrorType.SignError) {
-        showErrorMsg({
-          title: t`Failed to sign the message`,
-          // TODO change to human readable error message
-          description: signError?.message as string,
-        });
-      } else if (signError.type === VCSignErrorType.VerifyError) {
-        showErrorMsg({
-          title: t`Failed to verify signature`,
-          description: t`Your signature is invalid`,
-        });
-      } else if (signError.type === VCSignErrorType.VerifyFailed) {
-        showErrorMsg({
-          title: t`Invalid Signature`,
-          // TODO change to human readable error message
-          description: signError?.message as string,
-        });
-      } else {
-        showErrorMsg({
-          title: t`Failed to sign the message`,
-          description: t`Unknown error`,
-        });
-      }
-    }
-  }, [signError, showErrorMsg]);
 
   return (
     <>

--- a/src/features/account/AccountTEEndorsement.test.tsx
+++ b/src/features/account/AccountTEEndorsement.test.tsx
@@ -4,11 +4,8 @@ import { useEnsName } from 'wagmi';
 
 import { AccountTEEndorsement } from './AccountTEEndorsement';
 import type { VCSignError } from '../../hooks/useVerifiableCredential';
-import {
-  useVerifiableCredential,
-  VCSignErrorType,
-} from '../../hooks/useVerifiableCredential';
-import { TrustworthinessScope, trimAddress } from '../../utils';
+import { useVerifiableCredential } from '../../hooks/useVerifiableCredential';
+import { trimAddress, TrustworthinessScope } from '../../utils';
 import {
   render,
   VALID_ACCOUNT_1,
@@ -238,95 +235,6 @@ describe('AccountTEEndorsement', () => {
             level: 0,
           },
         ],
-      );
-    });
-  });
-
-  describe('with signError', () => {
-    it('shows `Failed to sign the message` toast message when signError is of type `SignError`', async () => {
-      buildEnsNameMock('mock.ens.name');
-      const { toastSpy } = buildToastSpy();
-      buildUseVerifiableCredentialMock({
-        type: VCSignErrorType.SignError,
-        message: 'sign error',
-      });
-
-      render(
-        <AccountTEEndorsement
-          address={VALID_ACCOUNT_1}
-          connectedAddress={VALID_ACCOUNT_2}
-        />,
-      );
-
-      expect(toastSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          title: 'Failed to sign the message',
-          description: 'sign error',
-        }),
-      );
-    });
-
-    it('shows `Failed to verify signature` toast message when signError is of type `VerifyError`', async () => {
-      buildEnsNameMock('mock.ens.name');
-      const { toastSpy } = buildToastSpy();
-      buildUseVerifiableCredentialMock({ type: VCSignErrorType.VerifyError });
-
-      render(
-        <AccountTEEndorsement
-          address={VALID_ACCOUNT_1}
-          connectedAddress={VALID_ACCOUNT_2}
-        />,
-      );
-
-      expect(toastSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          title: 'Failed to verify signature',
-          description: 'Your signature is invalid',
-        }),
-      );
-    });
-
-    it('shows `Invalid Signature` toast message when signError is of type `SignError`', async () => {
-      buildEnsNameMock('mock.ens.name');
-      const { toastSpy } = buildToastSpy();
-      buildUseVerifiableCredentialMock({
-        type: VCSignErrorType.VerifyFailed,
-        message: 'invalid signature',
-      });
-
-      render(
-        <AccountTEEndorsement
-          address={VALID_ACCOUNT_1}
-          connectedAddress={VALID_ACCOUNT_2}
-        />,
-      );
-
-      expect(toastSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          title: 'Invalid Signature',
-          description: 'invalid signature',
-        }),
-      );
-    });
-
-    it('shows `Failed to sign the message` toast message when signError is unknown', async () => {
-      buildEnsNameMock('mock.ens.name');
-      const { toastSpy } = buildToastSpy();
-      // @ts-expect-error - Invalid error.
-      buildUseVerifiableCredentialMock({ type: 'unknown' });
-
-      render(
-        <AccountTEEndorsement
-          address={VALID_ACCOUNT_1}
-          connectedAddress={VALID_ACCOUNT_2}
-        />,
-      );
-
-      expect(toastSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          title: 'Failed to sign the message',
-          description: 'Unknown error',
-        }),
       );
     });
   });

--- a/src/features/account/AccountTEEndorsement.tsx
+++ b/src/features/account/AccountTEEndorsement.tsx
@@ -1,19 +1,17 @@
 import { t } from '@lingui/macro';
 import type { Hex } from '@metamask/utils';
-import { useState, type FunctionComponent, useMemo, useEffect } from 'react';
+import { useMemo, useState, type FunctionComponent } from 'react';
 import { useEnsName } from 'wagmi';
 
 import { TEEndorsementModal } from './components';
 import { EndorseButton } from '../../components';
+import { useSignErrorHandler } from '../../hooks/useSignErrorHandler';
 import useToastMsg from '../../hooks/useToastMsg';
+import { useVerifiableCredential } from '../../hooks/useVerifiableCredential';
 import {
-  useVerifiableCredential,
-  VCSignErrorType,
-} from '../../hooks/useVerifiableCredential';
-import {
+  trimAddress,
   TrustworthinessScope,
   type Trustworthiness,
-  trimAddress,
 } from '../../utils';
 
 type AccountTEEndorsementProps = {
@@ -28,10 +26,12 @@ export const AccountTEEndorsement: FunctionComponent<
     address,
   });
 
-  const { showErrorMsg, showSuccessMsg } = useToastMsg();
+  const { showSuccessMsg } = useToastMsg();
 
   const { signMessage, signError, accountVCBuilder } =
     useVerifiableCredential();
+
+  useSignErrorHandler(signError);
 
   const trimedAddress = useMemo(() => trimAddress(address), [address]);
 
@@ -82,34 +82,6 @@ export const AccountTEEndorsement: FunctionComponent<
       setShowModal(false);
     }
   };
-
-  useEffect(() => {
-    if (signError) {
-      if (signError.type === VCSignErrorType.SignError) {
-        showErrorMsg({
-          title: t`Failed to sign the message`,
-          // TODO change to human readable error message
-          description: signError?.message as string,
-        });
-      } else if (signError.type === VCSignErrorType.VerifyError) {
-        showErrorMsg({
-          title: t`Failed to verify signature`,
-          description: t`Your signature is invalid`,
-        });
-      } else if (signError.type === VCSignErrorType.VerifyFailed) {
-        showErrorMsg({
-          title: t`Invalid Signature`,
-          // TODO change to human readable error message
-          description: signError?.message as string,
-        });
-      } else {
-        showErrorMsg({
-          title: t`Failed to sign the message`,
-          description: t`Unknown error`,
-        });
-      }
-    }
-  }, [signError, showErrorMsg]);
 
   return (
     <>

--- a/src/features/account/components/modals/AddToUserCircleModal.test.tsx
+++ b/src/features/account/components/modals/AddToUserCircleModal.test.tsx
@@ -1,13 +1,13 @@
 import { act, fireEvent } from '@testing-library/react';
 
 import { AddToUserCircleModal } from './AddToUserCircleModal';
-import { VCSignErrorType, useVerifiableCredential } from '../../../../hooks';
+import { useVerifiableCredential } from '../../../../hooks';
 import { createStore } from '../../../../store';
 import { trimAddress } from '../../../../utils';
 import {
-  render,
   VALID_ACCOUNT_1,
   VALID_ACCOUNT_2,
+  render,
 } from '../../../../utils/test-utils';
 
 jest.mock('../../../../hooks/useVerifiableCredential', () => ({
@@ -51,7 +51,7 @@ describe('AddToUserCircleModal', () => {
     ).toBeInTheDocument();
   });
 
-  it('sign button will do nothing if issuer address is not available', () => {
+  it('does not sign if issuer address is not available', () => {
     const mockSignMessage = jest.fn();
     mockUseVerifiableCredential.mockReturnValue({
       issuerAddress: null,
@@ -69,7 +69,7 @@ describe('AddToUserCircleModal', () => {
     expect(mockSignMessage).not.toHaveBeenCalled();
   });
 
-  it('sign button will do nothing if subject address is not available', () => {
+  it('does not sign if subject address is not available', () => {
     const mockSignMessage = jest.fn();
     mockUseVerifiableCredential.mockReturnValue({
       issuerAddress: VALID_ACCOUNT_1,
@@ -87,7 +87,7 @@ describe('AddToUserCircleModal', () => {
     expect(mockSignMessage).not.toHaveBeenCalled();
   });
 
-  it('show `Added to your trust circle` success message when sign message return valid signature', async () => {
+  it('shows `Added to your trust circle` success message when sign message return valid signature', async () => {
     mockUseVerifiableCredential.mockReturnValue({
       issuerAddress: VALID_ACCOUNT_1,
       signMessage: jest.fn().mockReturnValue(Promise.resolve('signature')),
@@ -114,7 +114,7 @@ describe('AddToUserCircleModal', () => {
     ).toBeInTheDocument();
   });
 
-  it('show do nothing when sign message return null signature', async () => {
+  it('does not sign when sign message return null signature', async () => {
     const mockSignMessage = jest.fn();
     mockSignMessage.mockReturnValue(Promise.resolve(null));
     mockUseVerifiableCredential.mockReturnValue({
@@ -139,87 +139,6 @@ describe('AddToUserCircleModal', () => {
 
     expect(mockSignMessage).toHaveBeenCalled();
     expect(queryByText('Added to your trust circle')).not.toBeInTheDocument();
-  });
-
-  it('show `The signature verification failed` when verify failed error detected', async () => {
-    mockUseVerifiableCredential.mockReturnValue({
-      issuerAddress: VALID_ACCOUNT_1,
-      signMessage: jest.fn().mockReturnValue(Promise.resolve(null)),
-      accountVCBuilder: {
-        buildAccountTrust: jest.fn().mockReturnValue('VC'),
-        getSignedAssertion: jest.fn().mockReturnValue('assertion'),
-      },
-      signError: {
-        type: VCSignErrorType.VerifyFailed,
-      },
-    });
-
-    const { getByText, queryByText } = render(
-      <AddToUserCircleModal subjectAddress="invalidAddress" />,
-      store,
-    );
-
-    const signButton = getByText('Sign to add');
-    act(() => {
-      fireEvent.click(signButton);
-    });
-
-    expect(queryByText('Error')).toBeInTheDocument();
-    expect(
-      queryByText('The signature verification failed'),
-    ).toBeInTheDocument();
-  });
-
-  it('show `The signature could not be created` error when sign error detected', async () => {
-    mockUseVerifiableCredential.mockReturnValue({
-      issuerAddress: VALID_ACCOUNT_1,
-      signMessage: jest.fn().mockReturnValue(Promise.resolve(null)),
-      accountVCBuilder: {
-        buildAccountTrust: jest.fn().mockReturnValue('VC'),
-        getSignedAssertion: jest.fn().mockReturnValue('assertion'),
-      },
-      signError: {
-        type: VCSignErrorType.SignError,
-      },
-    });
-
-    const { getByText, queryByText } = render(
-      <AddToUserCircleModal subjectAddress="errorAddress" />,
-      store,
-    );
-
-    const signButton = getByText('Sign to add');
-    fireEvent.click(signButton);
-
-    expect(queryByText('Error')).toBeInTheDocument();
-    expect(
-      queryByText('The signature could not be created'),
-    ).toBeInTheDocument();
-  });
-
-  it('show `The signature verification error` when verification error detected', async () => {
-    mockUseVerifiableCredential.mockReturnValue({
-      issuerAddress: VALID_ACCOUNT_1,
-      signMessage: jest.fn().mockReturnValue(Promise.resolve(null)),
-      accountVCBuilder: {
-        buildAccountTrust: jest.fn().mockReturnValue('VC'),
-        getSignedAssertion: jest.fn().mockReturnValue('assertion'),
-      },
-      signError: {
-        type: VCSignErrorType.VerifyError,
-      },
-    });
-
-    const { getByText, queryByText } = render(
-      <AddToUserCircleModal subjectAddress="errorAddress" />,
-      store,
-    );
-
-    const signButton = getByText('Sign to add');
-    fireEvent.click(signButton);
-
-    expect(queryByText('Error')).toBeInTheDocument();
-    expect(queryByText('The signature verification error')).toBeInTheDocument();
   });
 
   it('closes modal when close button is clicked', async () => {

--- a/src/features/account/components/modals/AddToUserCircleModal.tsx
+++ b/src/features/account/components/modals/AddToUserCircleModal.tsx
@@ -1,16 +1,16 @@
 import { Center, Link, Text, VStack } from '@chakra-ui/react';
 import { Trans, t } from '@lingui/macro';
 import type { FunctionComponent } from 'react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { isAddress } from 'viem';
 
 import { AvatarBlueIcon, RequestSignModal } from '../../../../components';
 import {
-  VCSignErrorType,
   useDispatch,
   useSelector,
   useVerifiableCredential,
 } from '../../../../hooks';
+import { useSignErrorHandler } from '../../../../hooks/useSignErrorHandler';
 import useToastMsg from '../../../../hooks/useToastMsg';
 import type { ApplicationState } from '../../../../store';
 import { trimAddress } from '../../../../utils';
@@ -32,7 +32,9 @@ export const AddToUserCircleModal: FunctionComponent<
   const { issuerAddress, signMessage, signError, accountVCBuilder } =
     useVerifiableCredential();
 
-  const { showSuccessMsg, showErrorMsg } = useToastMsg();
+  useSignErrorHandler(signError);
+
+  const { showSuccessMsg } = useToastMsg();
 
   const shortSubAddress = useMemo(
     () => trimAddress(subjectAddress),
@@ -73,25 +75,6 @@ export const AddToUserCircleModal: FunctionComponent<
       });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [issuerAddress, subjectAddress]);
-
-  useEffect(() => {
-    if (signError?.type === VCSignErrorType.SignError) {
-      showErrorMsg({
-        title: t`Error`,
-        description: t`The signature could not be created`,
-      });
-    } else if (signError?.type === VCSignErrorType.VerifyFailed) {
-      showErrorMsg({
-        title: t`Error`,
-        description: t`The signature verification failed`,
-      });
-    } else if (signError?.type === VCSignErrorType.VerifyError) {
-      showErrorMsg({
-        title: t`Error`,
-        description: t`The signature verification error`,
-      });
-    }
-  }, [signError, showErrorMsg]);
 
   return (
     <RequestSignModal

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -242,9 +242,6 @@ msgstr ""
 msgid "Endorsed"
 msgstr ""
 
-#: src/features/account/components/modals/AddToUserCircleModal.tsx
-#: src/features/account/components/modals/AddToUserCircleModal.tsx
-#: src/features/account/components/modals/AddToUserCircleModal.tsx
 #: src/features/account/MoreOptionMenu.tsx
 msgid "Error"
 msgstr ""
@@ -281,17 +278,11 @@ msgstr ""
 msgid "Failed to copy profile link to clipboard"
 msgstr ""
 
-#: src/features/account/AccountReport.tsx
-#: src/features/account/AccountReport.tsx
-#: src/features/account/AccountTEEndorsement.tsx
-#: src/features/account/AccountTEEndorsement.tsx
 #: src/hooks/useSignErrorHandler.ts
 #: src/hooks/useSignErrorHandler.ts
 msgid "Failed to sign the message"
 msgstr ""
 
-#: src/features/account/AccountReport.tsx
-#: src/features/account/AccountTEEndorsement.tsx
 #: src/hooks/useSignErrorHandler.ts
 #: src/hooks/useSignErrorHandler.ts
 msgid "Failed to verify signature"
@@ -387,8 +378,6 @@ msgstr ""
 msgid "Interoperability"
 msgstr ""
 
-#: src/features/account/AccountReport.tsx
-#: src/features/account/AccountTEEndorsement.tsx
 #: src/hooks/useSignErrorHandler.ts
 #: src/hooks/useSignErrorHandler.ts
 msgid "Invalid Signature"
@@ -646,18 +635,6 @@ msgstr ""
 msgid "The page you're looking for can't be found."
 msgstr ""
 
-#: src/features/account/components/modals/AddToUserCircleModal.tsx
-msgid "The signature could not be created"
-msgstr ""
-
-#: src/features/account/components/modals/AddToUserCircleModal.tsx
-msgid "The signature verification error"
-msgstr ""
-
-#: src/features/account/components/modals/AddToUserCircleModal.tsx
-msgid "The signature verification failed"
-msgstr ""
-
 #: src/features/snap/components/modals/ReportSnapModal.tsx
 msgid "This action will flag the snap as a malicious in your community."
 msgstr ""
@@ -684,11 +661,6 @@ msgstr ""
 
 #: src/features/account/components/modals/TEEndorsementModal.tsx
 msgid "Trusted technical abilities"
-msgstr ""
-
-#: src/features/account/AccountReport.tsx
-#: src/features/account/AccountTEEndorsement.tsx
-msgid "Unknown error"
 msgstr ""
 
 #: src/hooks/useSignErrorHandler.ts
@@ -758,9 +730,4 @@ msgstr ""
 
 #: src/features/account/components/modals/TEEndorsementModal.tsx
 msgid "Your level of confidence in <0>{trustEntity}</0> skill set"
-msgstr ""
-
-#: src/features/account/AccountReport.tsx
-#: src/features/account/AccountTEEndorsement.tsx
-msgid "Your signature is invalid"
 msgstr ""


### PR DESCRIPTION
## Description
This PR will apply `useSignErrorHandler` hook to all existing VC relative components so that we have central place to process signError display.

Following Components has been changed:
- AccountReport
- AccountTEEndorsement
- AddToUserCircleModal

### Related ticket

Fixes #

### Type of change

- [x] Chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
