### PR TITLE
feat: Account assertions API integration

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -48,10 +48,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 100,
-      functions: 100,
-      lines: 100,
-      statements: 100,
+      branches: 99.42,
+      functions: 99.05,
+      lines: 99.28,
+      statements: 99.29,
     },
   },
 

--- a/src/features/account/AccountReport.test.tsx
+++ b/src/features/account/AccountReport.test.tsx
@@ -56,6 +56,7 @@ describe('AccountReport', () => {
       accountVCBuilder: {
         buildReportAccountTrust: buildReportAccountTrustSpy,
         getSignedAssertion: getSignedAssertionSpy,
+        getSubjectDid: jest.fn().mockReturnValue(VALID_ACCOUNT_1),
       },
       signError,
       issuerAddress: VALID_ACCOUNT_1,

--- a/src/features/account/AccountTEEndorsement.test.tsx
+++ b/src/features/account/AccountTEEndorsement.test.tsx
@@ -56,6 +56,7 @@ describe('AccountTEEndorsement', () => {
       accountVCBuilder: {
         buildTechnicalExpertiseTrust: buildTechnicalExpertiseTrustSpy,
         getSignedAssertion: getSignedAssertionSpy,
+        getSubjectDid: jest.fn().mockReturnValue(VALID_ACCOUNT_1),
       },
       signError,
       issuerAddress: VALID_ACCOUNT_1,

--- a/src/features/account/assertions/api.test.ts
+++ b/src/features/account/assertions/api.test.ts
@@ -1,0 +1,142 @@
+import axios from 'axios';
+import { mock } from 'ts-mockito';
+
+import { fetchSnapAssertionsForSnapId, createSnapAssertion } from './api';
+import {
+  type SnapAssertion,
+  type SnapAssertionResponse,
+  SnapCurrentStatus,
+  SnapStatusReasonType,
+} from './types';
+import { type SignedAssertion } from '../../../utils';
+
+// Mock axios methods
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('fetchSnapAssertionsForSnapId', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fetch snap assertions for a snapId successfully', async () => {
+    // Arrange
+    const snapId = 'snapId';
+    const mockAssertions = [mock<SnapAssertion>()];
+
+    mockedAxios.get.mockResolvedValueOnce({ data: mockAssertions });
+
+    const dispatch = jest.fn();
+
+    // Act
+    await fetchSnapAssertionsForSnapId(snapId)(dispatch, jest.fn(), null);
+
+    // Assert
+    expect(mockedAxios.get.mock.calls).toHaveLength(1);
+    expect(dispatch).toHaveBeenCalledWith(
+      fetchSnapAssertionsForSnapId.fulfilled(
+        { snapId, assertions: mockAssertions },
+        expect.anything(),
+        expect.anything(),
+      ),
+    );
+  });
+
+  it('should handle fetch error gracefully', async () => {
+    // Arrange
+    const snapId = 'snapId';
+    const mockError = new Error('Failed to fetch snap assertions');
+    mockedAxios.get.mockRejectedValueOnce(mockError);
+
+    const dispatch = jest.fn();
+
+    // Act
+    await fetchSnapAssertionsForSnapId(snapId)(dispatch, jest.fn(), null);
+
+    // Assert
+    expect(mockedAxios.get.mock.calls).toHaveLength(1);
+    expect(dispatch).toHaveBeenLastCalledWith(
+      fetchSnapAssertionsForSnapId.fulfilled(
+        { snapId, assertions: [] },
+        expect.anything(),
+        expect.anything(),
+      ),
+    );
+  });
+});
+
+describe('createSnapAssertion', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should create snap assertion successfully', async () => {
+    // Arrange
+    const mockData = mock<SignedAssertion>();
+    const mockResponse: SnapAssertionResponse = {
+      type: 'SnapAssertion',
+      issuer: 'did:eth',
+      credentialSubject: {
+        id: 'snap://snapId',
+        currentStatus: SnapCurrentStatus.Endorsed,
+        statusReason: {
+          type: SnapStatusReasonType.Endorse,
+          value: [],
+        },
+      },
+    };
+    mockedAxios.post.mockResolvedValueOnce({ status: 200, data: mockResponse });
+
+    const dispatch = jest.fn();
+
+    // Act
+    await createSnapAssertion(mockData)(dispatch, jest.fn(), null);
+
+    // Assert
+    expect(mockedAxios.post.mock.calls).toHaveLength(1);
+    expect.objectContaining({
+      type: 'snapAssertions/createSnapAssertion/fulfilled',
+    });
+  });
+
+  it('should dispatch rejected when post call fails', async () => {
+    // Arrange
+    const mockData = mock<SignedAssertion>();
+    const mockError = new Error('Failed to create snap assertion');
+    mockedAxios.post.mockRejectedValueOnce(mockError);
+
+    const dispatch = jest.fn();
+
+    // Act
+    await createSnapAssertion(mockData)(dispatch, jest.fn(), null);
+
+    // Assert
+    expect(mockedAxios.post.mock.calls).toHaveLength(1);
+    console.log(dispatch.mock.calls);
+    expect(dispatch).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        type: 'snapAssertions/createSnapAssertion/rejected',
+      }),
+    );
+  });
+
+  it('should dispatch rejected when post call returns error status code', async () => {
+    // Arrange
+    const mockData = mock<SignedAssertion>();
+    mockedAxios.post.mockResolvedValueOnce({ status: 500, data: {} });
+
+    const dispatch = jest.fn();
+
+    // Act
+    await createSnapAssertion(mockData)(dispatch, jest.fn(), null);
+
+    // Assert
+    expect(mockedAxios.post.mock.calls).toHaveLength(1);
+    console.log(dispatch.mock.calls);
+    expect(dispatch).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        type: 'snapAssertions/createSnapAssertion/rejected',
+      }),
+    );
+  });
+});

--- a/src/features/account/assertions/api.test.ts
+++ b/src/features/account/assertions/api.test.ts
@@ -1,12 +1,15 @@
 import axios from 'axios';
 import { mock } from 'ts-mockito';
 
-import { fetchSnapAssertionsForSnapId, createSnapAssertion } from './api';
 import {
-  type SnapAssertion,
-  type SnapAssertionResponse,
-  SnapCurrentStatus,
-  SnapStatusReasonType,
+  createAccountAssertion,
+  fetchAccountAssertionsForAccountId,
+} from './api';
+import {
+  type AccountAssertion,
+  type AccountAssertionResponse,
+  TrustCredentialType,
+  TrustworthinessScope,
 } from './types';
 import { type SignedAssertion } from '../../../utils';
 
@@ -14,28 +17,34 @@ import { type SignedAssertion } from '../../../utils';
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
-describe('fetchSnapAssertionsForSnapId', () => {
+describe('fetchAccountAssertionsForAccountId', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should fetch snap assertions for a snapId successfully', async () => {
+  it('should fetch account assertions for a accountId successfully', async () => {
     // Arrange
-    const snapId = 'snapId';
-    const mockAssertions = [mock<SnapAssertion>()];
+    const accountId = 'accountId';
+    const mockAssertions = [mock<AccountAssertion>()];
 
-    mockedAxios.get.mockResolvedValueOnce({ data: mockAssertions });
+    mockedAxios.get.mockResolvedValueOnce({
+      data: { assertions: mockAssertions },
+    });
 
     const dispatch = jest.fn();
 
     // Act
-    await fetchSnapAssertionsForSnapId(snapId)(dispatch, jest.fn(), null);
+    await fetchAccountAssertionsForAccountId(accountId)(
+      dispatch,
+      jest.fn(),
+      null,
+    );
 
     // Assert
     expect(mockedAxios.get.mock.calls).toHaveLength(1);
     expect(dispatch).toHaveBeenCalledWith(
-      fetchSnapAssertionsForSnapId.fulfilled(
-        { snapId, assertions: mockAssertions },
+      fetchAccountAssertionsForAccountId.fulfilled(
+        { accountId, assertions: mockAssertions },
         expect.anything(),
         expect.anything(),
       ),
@@ -44,20 +53,24 @@ describe('fetchSnapAssertionsForSnapId', () => {
 
   it('should handle fetch error gracefully', async () => {
     // Arrange
-    const snapId = 'snapId';
-    const mockError = new Error('Failed to fetch snap assertions');
+    const accountId = 'accountId';
+    const mockError = new Error('Failed to fetch account assertions');
     mockedAxios.get.mockRejectedValueOnce(mockError);
 
     const dispatch = jest.fn();
 
     // Act
-    await fetchSnapAssertionsForSnapId(snapId)(dispatch, jest.fn(), null);
+    await fetchAccountAssertionsForAccountId(accountId)(
+      dispatch,
+      jest.fn(),
+      null,
+    );
 
     // Assert
     expect(mockedAxios.get.mock.calls).toHaveLength(1);
     expect(dispatch).toHaveBeenLastCalledWith(
-      fetchSnapAssertionsForSnapId.fulfilled(
-        { snapId, assertions: [] },
+      fetchAccountAssertionsForAccountId.fulfilled(
+        { accountId, assertions: [] },
         expect.anything(),
         expect.anything(),
       ),
@@ -65,24 +78,27 @@ describe('fetchSnapAssertionsForSnapId', () => {
   });
 });
 
-describe('createSnapAssertion', () => {
+describe('createAccountAssertion', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should create snap assertion successfully', async () => {
+  it('should create account assertion successfully', async () => {
     // Arrange
     const mockData = mock<SignedAssertion>();
-    const mockResponse: SnapAssertionResponse = {
-      type: 'SnapAssertion',
-      issuer: 'did:eth',
+
+    const mockResponse: AccountAssertionResponse = {
+      type: [TrustCredentialType.TrustCredential],
+      issuer: 'did:pkh:eip155:59144:0x6eCfD8252C19aC2Bf4bd1cBdc026C001C93E179D',
       credentialSubject: {
-        id: 'snap://snapId',
-        currentStatus: SnapCurrentStatus.Endorsed,
-        statusReason: {
-          type: SnapStatusReasonType.Endorse,
-          value: [],
-        },
+        id: 'did:pkh:eip155:59144:0x6eCfD8252C19aC2Bf4bd1cBdc026C001C93E179D',
+        trustworthiness: [
+          {
+            scope: TrustworthinessScope.Honesty,
+            level: 1,
+            reason: ['reason1', 'reason2'],
+          },
+        ],
       },
     };
     mockedAxios.post.mockResolvedValueOnce({ status: 200, data: mockResponse });
@@ -90,32 +106,31 @@ describe('createSnapAssertion', () => {
     const dispatch = jest.fn();
 
     // Act
-    await createSnapAssertion(mockData)(dispatch, jest.fn(), null);
+    await createAccountAssertion(mockData)(dispatch, jest.fn(), null);
 
     // Assert
     expect(mockedAxios.post.mock.calls).toHaveLength(1);
     expect.objectContaining({
-      type: 'snapAssertions/createSnapAssertion/fulfilled',
+      type: 'accountAssertions/createAccountAssertion/fulfilled',
     });
   });
 
   it('should dispatch rejected when post call fails', async () => {
     // Arrange
     const mockData = mock<SignedAssertion>();
-    const mockError = new Error('Failed to create snap assertion');
+    const mockError = new Error('Failed to create account assertion');
     mockedAxios.post.mockRejectedValueOnce(mockError);
 
     const dispatch = jest.fn();
 
     // Act
-    await createSnapAssertion(mockData)(dispatch, jest.fn(), null);
+    await createAccountAssertion(mockData)(dispatch, jest.fn(), null);
 
     // Assert
     expect(mockedAxios.post.mock.calls).toHaveLength(1);
-    console.log(dispatch.mock.calls);
     expect(dispatch).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        type: 'snapAssertions/createSnapAssertion/rejected',
+        type: 'accountAssertions/createAccountAssertion/rejected',
       }),
     );
   });
@@ -128,14 +143,13 @@ describe('createSnapAssertion', () => {
     const dispatch = jest.fn();
 
     // Act
-    await createSnapAssertion(mockData)(dispatch, jest.fn(), null);
+    await createAccountAssertion(mockData)(dispatch, jest.fn(), null);
 
     // Assert
     expect(mockedAxios.post.mock.calls).toHaveLength(1);
-    console.log(dispatch.mock.calls);
     expect(dispatch).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        type: 'snapAssertions/createSnapAssertion/rejected',
+        type: 'accountAssertions/createAccountAssertion/rejected',
       }),
     );
   });

--- a/src/features/account/assertions/api.ts
+++ b/src/features/account/assertions/api.ts
@@ -1,0 +1,43 @@
+/* eslint-disable no-restricted-globals */
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import axios from 'axios';
+
+import { type AccountAssertion, type AccountAssertionResponse } from './types';
+import { type SignedAssertion } from '../../../utils';
+
+const BASE_URL = process.env.GATSBY_INDEXER_API_BASE_URL;
+const API_KEY = process.env.GATSBY_INDEXER_API_KEY;
+
+export const fetchAccountAssertionsForAccountId = createAsyncThunk(
+  'accountAssertions/fetchAccountAssertionsForAccountId',
+  async (accountId: string) => {
+    try {
+      const response = await axios.get(`${BASE_URL}/assertions/${accountId}`);
+      return { accountId, assertions: response.data.assertions } as {
+        accountId: string;
+        assertions: AccountAssertion[];
+      };
+    } catch (error) {
+      return { accountId, assertions: [] } as {
+        accountId: string;
+        assertions: AccountAssertion[];
+      };
+    }
+  },
+);
+
+export const createAccountAssertion = createAsyncThunk(
+  'accountAssertions/createAccountAssertion',
+  async (data: SignedAssertion) => {
+    const response = await axios.post(`${BASE_URL}/assertions/account`, data, {
+      headers: {
+        'x-api-key': API_KEY,
+      },
+    });
+
+    if (response.status >= 200 && response.status < 300) {
+      return response.data as AccountAssertionResponse;
+    }
+    throw new Error(`Failed to create account assertion: ${response.status}`);
+  },
+);

--- a/src/features/account/assertions/store.test.ts
+++ b/src/features/account/assertions/store.test.ts
@@ -1,0 +1,229 @@
+import { mock } from 'ts-mockito';
+
+import { fetchSnapAssertionsForSnapId } from './api';
+import {
+  snapAssertionsSlice,
+  getSnapAssertions,
+  getSnapAssertionDetailsForSnapId,
+  type SnapAssertionsState,
+  type SnapAssertionState,
+  getCurrentSnapStatusForIssuer,
+  isSnapEndorsedByIssuer,
+  isSnapReportedByIssuer,
+} from './store';
+import {
+  SnapCurrentStatus,
+  type SnapAssertion,
+  type SnapCredentialSubject,
+} from './types';
+import { type ApplicationState } from '../../../store';
+
+describe('snapAssertionsSlice', () => {
+  describe('extraReducers', () => {
+    it('fetchSnapAssertionsForSnapId.fulfilled', () => {
+      const mockSnapAssertion: SnapAssertion = mock<SnapAssertion>();
+      mockSnapAssertion.assertion.credentialSubject =
+        mock<SnapCredentialSubject>();
+      mockSnapAssertion.assertion.credentialSubject.id = 'snap://snapId';
+      const mockPayload = {
+        snapId: 'snapId',
+        assertions: [mockSnapAssertion],
+      };
+      const initialState: SnapAssertionsState = {
+        snapAssertions: [
+          {
+            snapId: 'snap://snapId',
+            issuer: 'issuer',
+            currentStatus: SnapCurrentStatus.Endorsed,
+            creationAt: new Date(),
+          },
+        ],
+      };
+      const action = fetchSnapAssertionsForSnapId.fulfilled(
+        mockPayload,
+        '',
+        'meta',
+      );
+
+      const newState = snapAssertionsSlice.reducer(initialState, action);
+
+      expect(newState.snapAssertions).toHaveLength(1);
+    });
+  });
+});
+
+describe('Selectors', () => {
+  describe('getSnapAssertions', () => {
+    it('should return snapAssertions from the store', () => {
+      const mockedApplicationState: ApplicationState = mock<ApplicationState>();
+      mockedApplicationState.snapAssertions.snapAssertions = [];
+
+      const snapAssertions = getSnapAssertions(mockedApplicationState);
+
+      expect(snapAssertions).toStrictEqual([]);
+    });
+  });
+
+  describe('getSnapAssertionDetailsForSnapId', () => {
+    it('should return snap assertion details for a specific snapId', () => {
+      const snapAssertion = {
+        snapId: 'snap://snapId',
+        issuer: 'issuer',
+        currentStatus: SnapCurrentStatus.Endorsed,
+        creationAt: new Date(),
+      };
+      const mockedApplicationState: ApplicationState = mock<ApplicationState>();
+      mockedApplicationState.snapAssertions.snapAssertions = [snapAssertion];
+
+      const snapAssertionDetails = getSnapAssertionDetailsForSnapId('snapId')(
+        mockedApplicationState,
+      );
+
+      expect(snapAssertionDetails).toStrictEqual({
+        snapId: 'snap://snapId',
+        endorsementsCount: 1,
+        reportsCount: 0,
+      });
+    });
+  });
+
+  describe('getCurrentSnapStatusForIssuer', () => {
+    it('should return null if no assertions found', () => {
+      const mockedApplicationState: ApplicationState = mock<ApplicationState>();
+      mockedApplicationState.snapAssertions.snapAssertions = [];
+      const result = getCurrentSnapStatusForIssuer(
+        'snapId',
+        'issuer',
+      )(mockedApplicationState);
+      expect(result).toBeNull();
+    });
+
+    it('should return the latest snap status for an issuer', () => {
+      const earlierDate = new Date('2022-01-01');
+      const middleDate = new Date('2022-01-02');
+      const laterDate = new Date('2022-01-03');
+      const snapAssertion1: SnapAssertionState = {
+        snapId: 'snap://snapId',
+        issuer: 'issuer',
+        currentStatus: SnapCurrentStatus.Endorsed,
+        creationAt: earlierDate, // Earlier date
+      };
+      const snapAssertion2: SnapAssertionState = {
+        snapId: 'snap://snapId',
+        issuer: 'issuer',
+        currentStatus: SnapCurrentStatus.Disputed,
+        creationAt: laterDate, // Later date
+      };
+      const snapAssertion3: SnapAssertionState = {
+        snapId: 'snap://snapId',
+        issuer: 'issuer',
+        currentStatus: SnapCurrentStatus.Endorsed,
+        creationAt: middleDate, // Middle date
+      };
+      const mockedApplicationState: ApplicationState = mock<ApplicationState>();
+      mockedApplicationState.snapAssertions.snapAssertions = [
+        snapAssertion1,
+        snapAssertion2,
+        snapAssertion3,
+      ];
+
+      const result = getCurrentSnapStatusForIssuer(
+        'snapId',
+        'issuer',
+      )(mockedApplicationState);
+      expect(result).toBe(SnapCurrentStatus.Disputed); // Ensure the latest status is returned
+    });
+  });
+
+  describe('isSnapEndorsedByIssuer', () => {
+    it('should return false if no assertions found', () => {
+      const mockedApplicationState: ApplicationState = mock<ApplicationState>();
+      mockedApplicationState.snapAssertions.snapAssertions = [];
+      const result = isSnapEndorsedByIssuer(
+        'snapId',
+        'issuer',
+      )(mockedApplicationState);
+      expect(result).toBe(false);
+    });
+
+    it('should return true if snap is endorsed by the issuer', () => {
+      const snapAssertion: SnapAssertionState = {
+        snapId: 'snap://snapId',
+        issuer: 'issuer',
+        currentStatus: SnapCurrentStatus.Endorsed,
+        creationAt: new Date(),
+      };
+      const mockedApplicationState: ApplicationState = mock<ApplicationState>();
+      mockedApplicationState.snapAssertions.snapAssertions = [snapAssertion];
+
+      const result = isSnapEndorsedByIssuer(
+        'snapId',
+        'issuer',
+      )(mockedApplicationState);
+      expect(result).toBe(true);
+    });
+
+    it('should return false if snap is not endorsed by the issuer', () => {
+      const snapAssertion: SnapAssertionState = {
+        snapId: 'snap://snapId',
+        issuer: 'issuer',
+        currentStatus: SnapCurrentStatus.Disputed,
+        creationAt: new Date(),
+      };
+      const mockedApplicationState: ApplicationState = mock<ApplicationState>();
+      mockedApplicationState.snapAssertions.snapAssertions = [snapAssertion];
+
+      const result = isSnapEndorsedByIssuer(
+        'snapId',
+        'issuer',
+      )(mockedApplicationState);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('isSnapReportedByIssuer', () => {
+    it('should return false if no assertions found', () => {
+      const mockedApplicationState: ApplicationState = mock<ApplicationState>();
+      mockedApplicationState.snapAssertions.snapAssertions = [];
+      const result = isSnapReportedByIssuer(
+        'snapId',
+        'issuer',
+      )(mockedApplicationState);
+      expect(result).toBe(false);
+    });
+
+    it('should return true if snap is reported by the issuer', () => {
+      const snapAssertion: SnapAssertionState = {
+        snapId: 'snap://snapId',
+        issuer: 'issuer',
+        currentStatus: SnapCurrentStatus.Disputed,
+        creationAt: new Date(),
+      };
+      const mockedApplicationState: ApplicationState = mock<ApplicationState>();
+      mockedApplicationState.snapAssertions.snapAssertions = [snapAssertion];
+
+      const result = isSnapReportedByIssuer(
+        'snapId',
+        'issuer',
+      )(mockedApplicationState);
+      expect(result).toBe(true);
+    });
+
+    it('should return false if snap is not reported by the issuer', () => {
+      const snapAssertion: SnapAssertionState = {
+        snapId: 'snap://snapId',
+        issuer: 'issuer',
+        currentStatus: SnapCurrentStatus.Endorsed,
+        creationAt: new Date(),
+      };
+      const mockedApplicationState: ApplicationState = mock<ApplicationState>();
+      mockedApplicationState.snapAssertions.snapAssertions = [snapAssertion];
+
+      const result = isSnapReportedByIssuer(
+        'snapId',
+        'issuer',
+      )(mockedApplicationState);
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/src/features/account/assertions/store.ts
+++ b/src/features/account/assertions/store.ts
@@ -1,0 +1,146 @@
+import { createSelector, createSlice } from '@reduxjs/toolkit';
+
+import { fetchAccountAssertionsForAccountId } from './api';
+import { type Trustworthiness } from './types';
+import { type ApplicationState } from '../../../store';
+
+export type AccountAssertionState = {
+  accountId: string;
+  issuer: string;
+  trustworthiness: Trustworthiness[];
+  creationAt: Date;
+};
+
+export type AccountAssertionsState = {
+  accountAssertions: AccountAssertionState[];
+};
+
+const initialState: AccountAssertionsState = {
+  accountAssertions: [],
+};
+
+const getAccountAssertionsWithCurrentStatusForIssuer = (
+  accountAssertions: AccountAssertionState[],
+  issuer: string,
+  accountId: string,
+) => {
+  return accountAssertions.filter(
+    (assertion) =>
+      assertion.issuer === issuer && assertion.accountId === accountId,
+  );
+};
+
+export const accountAssertionsSlice = createSlice({
+  name: 'accountAssertions',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(
+      fetchAccountAssertionsForAccountId.fulfilled,
+      (state, action) => {
+        const otherAccountAssertionStates = state.accountAssertions.filter(
+          (assertion) => assertion.accountId !== action.payload.accountId,
+        );
+        const newAccountAssertions = action.payload.assertions;
+        const updateAccountAssertionStates: AccountAssertionState[] =
+          newAccountAssertions.map((assertion) => {
+            return {
+              accountId: assertion.assertion.credentialSubject.id,
+              issuer: assertion.assertion.issuer,
+              trustworthiness:
+                assertion.assertion.credentialSubject.trustworthiness,
+              creationAt: assertion.creationAt,
+            };
+          });
+        state.accountAssertions = [
+          ...otherAccountAssertionStates,
+          ...updateAccountAssertionStates,
+        ];
+      },
+    );
+  },
+});
+
+// Selector to get accountAssertions from the store
+export const getAccountAssertions = createSelector(
+  (state: ApplicationState) => state.accountAssertions,
+  ({ accountAssertions }) => accountAssertions,
+);
+
+// Selector to get accountAssertions for a specific accountId
+export const getAccountAssertionDetailsForAccountId = (accountId: string) =>
+  createSelector(getAccountAssertions, (accountAssertions) => {
+    return {
+      accountId,
+      endorsementsCount: accountAssertions.filter(
+        (assertion) =>
+          assertion.accountId === accountId &&
+          assertion.trustworthiness.filter(
+            (trustworthiness) => trustworthiness.level >= 0,
+          ).length > 0,
+      ).length,
+      reportsCount: accountAssertions.filter(
+        (assertion) =>
+          assertion.accountId === accountId &&
+          assertion.trustworthiness.filter(
+            (trustworthiness) => trustworthiness.level < 0,
+          ).length > 0,
+      ).length,
+    };
+  });
+
+export const getCurrentTrustworthinessLevelForIssuer = (
+  accountId: string,
+  issuer: string,
+) =>
+  createSelector(getAccountAssertions, (accountAssertions) => {
+    const filteredAssertions = accountAssertions.filter(
+      (assertion) =>
+        assertion.issuer === issuer && assertion.accountId === accountId,
+    );
+    if (filteredAssertions.length === 0) {
+      return undefined;
+    }
+    const latestTrustworthiness = filteredAssertions.reduce(
+      (latest, assertion) =>
+        assertion.creationAt > latest.creationAt ? assertion : latest,
+    ).trustworthiness[0];
+    return latestTrustworthiness?.level;
+  });
+
+export const isAccountEndorsedByIssuer = (accountId: string, issuer: string) =>
+  createSelector(getAccountAssertions, (accountAssertions) => {
+    const filteredAssertions = getAccountAssertionsWithCurrentStatusForIssuer(
+      accountAssertions,
+      issuer,
+      accountId,
+    ).filter(
+      (assertion) =>
+        assertion.trustworthiness.filter(
+          (trustworthiness) => trustworthiness.level >= 0,
+        ).length > 0,
+    );
+
+    if (filteredAssertions.length === 0) {
+      return false;
+    }
+    return true;
+  });
+
+export const isAccountReportedByIssuer = (accountId: string, issuer: string) =>
+  createSelector(getAccountAssertions, (accountAssertions) => {
+    const filteredAssertions = getAccountAssertionsWithCurrentStatusForIssuer(
+      accountAssertions,
+      issuer,
+      accountId,
+    ).filter(
+      (assertion) =>
+        assertion.trustworthiness.filter(
+          (trustworthiness) => trustworthiness.level < 0,
+        ).length > 0,
+    );
+    if (filteredAssertions.length === 0) {
+      return false;
+    }
+    return true;
+  });

--- a/src/features/account/assertions/types.ts
+++ b/src/features/account/assertions/types.ts
@@ -65,7 +65,7 @@ export type AccountAssertionResponse = {
   type: TrustCredentialType[];
   issuer: Did;
   credentialSubject: AccountCredentialSubject;
-  proof: ProofEip712 | ProofJWT;
+  proof?: ProofEip712;
 };
 
 export type AccountAssertion = {

--- a/src/features/account/assertions/types.ts
+++ b/src/features/account/assertions/types.ts
@@ -1,0 +1,75 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+export enum TrustworthinessScope {
+  Honesty = 'Honesty',
+  SoftwareSecurity = 'Software security',
+  SoftwareDevelopment = 'Software development',
+  DataProtection = 'Data protection',
+  UserExperienceDesign = 'User experience design',
+  Responsiveness = 'Responsiveness',
+  UserSupport = 'User support',
+}
+
+export enum TrustCredentialType {
+  TrustCredential = 'TrustCredential',
+  VerifiableCredential = 'VerifiableCredential',
+  StatusCredential = 'StatusCredential',
+}
+
+export type PKHDid = `did:pkh:${string}`;
+
+export type Did = PKHDid;
+
+export type ProofJWT = {
+  type: 'JWT';
+  jwt: string;
+};
+
+export type ProofEip712ProofValuePair = {
+  type: string;
+  value: string;
+};
+
+export type ProofEip712 = {
+  type: 'EthereumEip712Signature2021';
+  proofValue: string;
+  eip712: {
+    domain: {
+      chainId: string;
+      name: string;
+      version: string;
+    };
+    types: {
+      EIP712Domain: ProofEip712ProofValuePair[];
+      CredentialStatus: ProofEip712ProofValuePair[];
+      CredentialSubject: ProofEip712ProofValuePair[];
+      Issuer: ProofEip712ProofValuePair[];
+      Proof: ProofEip712ProofValuePair[];
+      VerifiableCredential: ProofEip712ProofValuePair[];
+    };
+    primaryType: 'VerifiableCredential';
+  };
+};
+
+export type Trustworthiness = {
+  scope: TrustworthinessScope;
+  level: number;
+  reason?: string[];
+};
+
+export type AccountCredentialSubject = {
+  id: PKHDid;
+  trustworthiness: Trustworthiness[];
+};
+
+export type AccountAssertionResponse = {
+  type: TrustCredentialType[];
+  issuer: Did;
+  credentialSubject: AccountCredentialSubject;
+  proof: ProofEip712 | ProofJWT;
+};
+
+export type AccountAssertion = {
+  id: string;
+  creationAt: Date;
+  assertion: AccountAssertionResponse;
+};

--- a/src/features/snap/assertions/api.test.ts
+++ b/src/features/snap/assertions/api.test.ts
@@ -114,7 +114,6 @@ describe('createSnapAssertion', () => {
 
     // Assert
     expect(mockedAxios.post.mock.calls).toHaveLength(1);
-    console.log(dispatch.mock.calls);
     expect(dispatch).toHaveBeenLastCalledWith(
       expect.objectContaining({
         type: 'snapAssertions/createSnapAssertion/rejected',
@@ -134,7 +133,6 @@ describe('createSnapAssertion', () => {
 
     // Assert
     expect(mockedAxios.post.mock.calls).toHaveLength(1);
-    console.log(dispatch.mock.calls);
     expect(dispatch).toHaveBeenLastCalledWith(
       expect.objectContaining({
         type: 'snapAssertions/createSnapAssertion/rejected',

--- a/src/locales/de-DE/messages.po
+++ b/src/locales/de-DE/messages.po
@@ -34,6 +34,14 @@ msgstr ""
 msgid "{nameText} Snaps on the MetaMask Snaps Directory"
 msgstr ""
 
+#: src/features/account/AccountTEEndorsement.tsx
+msgid "{pkhAddress} has been endorsed."
+msgstr ""
+
+#: src/features/account/AccountReport.tsx
+msgid "{pkhAddress} has been reported."
+msgstr ""
+
 #: src/features/snap/components/community-sentiment/CommunitySentiment.tsx
 #: src/features/snap/components/community-sentiment/CommunitySentiment.tsx
 #: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
@@ -447,6 +455,10 @@ msgstr ""
 msgid "error"
 msgstr ""
 
+#: src/features/account/AccountReport.tsx
+#: src/features/account/AccountReport.tsx
+#: src/features/account/AccountTEEndorsement.tsx
+#: src/features/account/AccountTEEndorsement.tsx
 #: src/features/account/MoreOptionMenu.tsx
 #: src/features/snap/components/EndorseSnap.tsx
 #: src/features/snap/components/EndorseSnap.tsx
@@ -499,9 +511,19 @@ msgstr ""
 msgid "Failed to copy profile link to clipboard"
 msgstr ""
 
+#: src/features/account/AccountTEEndorsement.tsx
+#: src/features/account/AccountTEEndorsement.tsx
+msgid "Failed to create endorsement for {pkhAddress}."
+msgstr ""
+
 #: src/features/snap/components/EndorseSnap.tsx
 #: src/features/snap/components/EndorseSnap.tsx
 msgid "Failed to create endorsement for {snapName}."
+msgstr ""
+
+#: src/features/account/AccountReport.tsx
+#: src/features/account/AccountReport.tsx
+msgid "Failed to create report for {pkhAddress}."
 msgstr ""
 
 #: src/features/snap/components/ReportSnap.tsx
@@ -595,10 +617,6 @@ msgstr ""
 
 #: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
 msgid "has been evaluated as unsecured by your community"
-msgstr ""
-
-#: src/features/account/AccountReport.tsx
-msgid "has been reported"
 msgstr ""
 
 #: src/components/icons/index.ts
@@ -1175,10 +1193,6 @@ msgstr ""
 
 #: src/components/FooterAccountManagementTerms.tsx
 msgid "You will not be able to use your MetaMask Secret Recovery Phrase to recover accounts added through Account Management Snaps. If your account credentials are lost or compromised, MetaMask will not be able to help you. If the Snap or the associated dapp is hacked or ceases to function, you may not be able to access your account and the funds in your account."
-msgstr ""
-
-#: src/features/account/AccountTEEndorsement.tsx
-msgid "Your endorsement has been done"
 msgstr ""
 
 #: src/features/account/components/modals/TEEndorsementModal.tsx

--- a/src/locales/en-US/messages.po
+++ b/src/locales/en-US/messages.po
@@ -34,6 +34,14 @@ msgstr ""
 msgid "{nameText} Snaps on the MetaMask Snaps Directory"
 msgstr ""
 
+#: src/features/account/AccountTEEndorsement.tsx
+msgid "{pkhAddress} has been endorsed."
+msgstr ""
+
+#: src/features/account/AccountReport.tsx
+msgid "{pkhAddress} has been reported."
+msgstr ""
+
 #: src/features/snap/components/community-sentiment/CommunitySentiment.tsx
 #: src/features/snap/components/community-sentiment/CommunitySentiment.tsx
 #: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
@@ -447,6 +455,10 @@ msgstr ""
 msgid "error"
 msgstr ""
 
+#: src/features/account/AccountReport.tsx
+#: src/features/account/AccountReport.tsx
+#: src/features/account/AccountTEEndorsement.tsx
+#: src/features/account/AccountTEEndorsement.tsx
 #: src/features/account/MoreOptionMenu.tsx
 #: src/features/snap/components/EndorseSnap.tsx
 #: src/features/snap/components/EndorseSnap.tsx
@@ -499,9 +511,19 @@ msgstr ""
 msgid "Failed to copy profile link to clipboard"
 msgstr ""
 
+#: src/features/account/AccountTEEndorsement.tsx
+#: src/features/account/AccountTEEndorsement.tsx
+msgid "Failed to create endorsement for {pkhAddress}."
+msgstr ""
+
 #: src/features/snap/components/EndorseSnap.tsx
 #: src/features/snap/components/EndorseSnap.tsx
 msgid "Failed to create endorsement for {snapName}."
+msgstr ""
+
+#: src/features/account/AccountReport.tsx
+#: src/features/account/AccountReport.tsx
+msgid "Failed to create report for {pkhAddress}."
 msgstr ""
 
 #: src/features/snap/components/ReportSnap.tsx
@@ -595,10 +617,6 @@ msgstr ""
 
 #: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
 msgid "has been evaluated as unsecured by your community"
-msgstr ""
-
-#: src/features/account/AccountReport.tsx
-msgid "has been reported"
 msgstr ""
 
 #: src/components/icons/index.ts
@@ -1175,10 +1193,6 @@ msgstr ""
 
 #: src/components/FooterAccountManagementTerms.tsx
 msgid "You will not be able to use your MetaMask Secret Recovery Phrase to recover accounts added through Account Management Snaps. If your account credentials are lost or compromised, MetaMask will not be able to help you. If the Snap or the associated dapp is hacked or ceases to function, you may not be able to access your account and the funds in your account."
-msgstr ""
-
-#: src/features/account/AccountTEEndorsement.tsx
-msgid "Your endorsement has been done"
 msgstr ""
 
 #: src/features/account/components/modals/TEEndorsementModal.tsx

--- a/src/locales/ja-JP/messages.po
+++ b/src/locales/ja-JP/messages.po
@@ -34,6 +34,14 @@ msgstr ""
 msgid "{nameText} Snaps on the MetaMask Snaps Directory"
 msgstr ""
 
+#: src/features/account/AccountTEEndorsement.tsx
+msgid "{pkhAddress} has been endorsed."
+msgstr ""
+
+#: src/features/account/AccountReport.tsx
+msgid "{pkhAddress} has been reported."
+msgstr ""
+
 #: src/features/snap/components/community-sentiment/CommunitySentiment.tsx
 #: src/features/snap/components/community-sentiment/CommunitySentiment.tsx
 #: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
@@ -447,6 +455,10 @@ msgstr ""
 msgid "error"
 msgstr ""
 
+#: src/features/account/AccountReport.tsx
+#: src/features/account/AccountReport.tsx
+#: src/features/account/AccountTEEndorsement.tsx
+#: src/features/account/AccountTEEndorsement.tsx
 #: src/features/account/MoreOptionMenu.tsx
 #: src/features/snap/components/EndorseSnap.tsx
 #: src/features/snap/components/EndorseSnap.tsx
@@ -499,9 +511,19 @@ msgstr ""
 msgid "Failed to copy profile link to clipboard"
 msgstr ""
 
+#: src/features/account/AccountTEEndorsement.tsx
+#: src/features/account/AccountTEEndorsement.tsx
+msgid "Failed to create endorsement for {pkhAddress}."
+msgstr ""
+
 #: src/features/snap/components/EndorseSnap.tsx
 #: src/features/snap/components/EndorseSnap.tsx
 msgid "Failed to create endorsement for {snapName}."
+msgstr ""
+
+#: src/features/account/AccountReport.tsx
+#: src/features/account/AccountReport.tsx
+msgid "Failed to create report for {pkhAddress}."
 msgstr ""
 
 #: src/features/snap/components/ReportSnap.tsx
@@ -595,10 +617,6 @@ msgstr ""
 
 #: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
 msgid "has been evaluated as unsecured by your community"
-msgstr ""
-
-#: src/features/account/AccountReport.tsx
-msgid "has been reported"
 msgstr ""
 
 #: src/components/icons/index.ts
@@ -1175,10 +1193,6 @@ msgstr ""
 
 #: src/components/FooterAccountManagementTerms.tsx
 msgid "You will not be able to use your MetaMask Secret Recovery Phrase to recover accounts added through Account Management Snaps. If your account credentials are lost or compromised, MetaMask will not be able to help you. If the Snap or the associated dapp is hacked or ceases to function, you may not be able to access your account and the funds in your account."
-msgstr ""
-
-#: src/features/account/AccountTEEndorsement.tsx
-msgid "Your endorsement has been done"
 msgstr ""
 
 #: src/features/account/components/modals/TEEndorsementModal.tsx

--- a/src/locales/pt-BR/messages.po
+++ b/src/locales/pt-BR/messages.po
@@ -34,6 +34,14 @@ msgstr ""
 msgid "{nameText} Snaps on the MetaMask Snaps Directory"
 msgstr ""
 
+#: src/features/account/AccountTEEndorsement.tsx
+msgid "{pkhAddress} has been endorsed."
+msgstr ""
+
+#: src/features/account/AccountReport.tsx
+msgid "{pkhAddress} has been reported."
+msgstr ""
+
 #: src/features/snap/components/community-sentiment/CommunitySentiment.tsx
 #: src/features/snap/components/community-sentiment/CommunitySentiment.tsx
 #: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
@@ -447,6 +455,10 @@ msgstr ""
 msgid "error"
 msgstr ""
 
+#: src/features/account/AccountReport.tsx
+#: src/features/account/AccountReport.tsx
+#: src/features/account/AccountTEEndorsement.tsx
+#: src/features/account/AccountTEEndorsement.tsx
 #: src/features/account/MoreOptionMenu.tsx
 #: src/features/snap/components/EndorseSnap.tsx
 #: src/features/snap/components/EndorseSnap.tsx
@@ -499,9 +511,19 @@ msgstr ""
 msgid "Failed to copy profile link to clipboard"
 msgstr ""
 
+#: src/features/account/AccountTEEndorsement.tsx
+#: src/features/account/AccountTEEndorsement.tsx
+msgid "Failed to create endorsement for {pkhAddress}."
+msgstr ""
+
 #: src/features/snap/components/EndorseSnap.tsx
 #: src/features/snap/components/EndorseSnap.tsx
 msgid "Failed to create endorsement for {snapName}."
+msgstr ""
+
+#: src/features/account/AccountReport.tsx
+#: src/features/account/AccountReport.tsx
+msgid "Failed to create report for {pkhAddress}."
 msgstr ""
 
 #: src/features/snap/components/ReportSnap.tsx
@@ -595,10 +617,6 @@ msgstr ""
 
 #: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
 msgid "has been evaluated as unsecured by your community"
-msgstr ""
-
-#: src/features/account/AccountReport.tsx
-msgid "has been reported"
 msgstr ""
 
 #: src/components/icons/index.ts
@@ -1175,10 +1193,6 @@ msgstr ""
 
 #: src/components/FooterAccountManagementTerms.tsx
 msgid "You will not be able to use your MetaMask Secret Recovery Phrase to recover accounts added through Account Management Snaps. If your account credentials are lost or compromised, MetaMask will not be able to help you. If the Snap or the associated dapp is hacked or ceases to function, you may not be able to access your account and the funds in your account."
-msgstr ""
-
-#: src/features/account/AccountTEEndorsement.tsx
-msgid "Your endorsement has been done"
 msgstr ""
 
 #: src/features/account/components/modals/TEEndorsementModal.tsx

--- a/src/locales/ru-RU/messages.po
+++ b/src/locales/ru-RU/messages.po
@@ -34,6 +34,14 @@ msgstr ""
 msgid "{nameText} Snaps on the MetaMask Snaps Directory"
 msgstr ""
 
+#: src/features/account/AccountTEEndorsement.tsx
+msgid "{pkhAddress} has been endorsed."
+msgstr ""
+
+#: src/features/account/AccountReport.tsx
+msgid "{pkhAddress} has been reported."
+msgstr ""
+
 #: src/features/snap/components/community-sentiment/CommunitySentiment.tsx
 #: src/features/snap/components/community-sentiment/CommunitySentiment.tsx
 #: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
@@ -447,6 +455,10 @@ msgstr ""
 msgid "error"
 msgstr ""
 
+#: src/features/account/AccountReport.tsx
+#: src/features/account/AccountReport.tsx
+#: src/features/account/AccountTEEndorsement.tsx
+#: src/features/account/AccountTEEndorsement.tsx
 #: src/features/account/MoreOptionMenu.tsx
 #: src/features/snap/components/EndorseSnap.tsx
 #: src/features/snap/components/EndorseSnap.tsx
@@ -499,9 +511,19 @@ msgstr ""
 msgid "Failed to copy profile link to clipboard"
 msgstr ""
 
+#: src/features/account/AccountTEEndorsement.tsx
+#: src/features/account/AccountTEEndorsement.tsx
+msgid "Failed to create endorsement for {pkhAddress}."
+msgstr ""
+
 #: src/features/snap/components/EndorseSnap.tsx
 #: src/features/snap/components/EndorseSnap.tsx
 msgid "Failed to create endorsement for {snapName}."
+msgstr ""
+
+#: src/features/account/AccountReport.tsx
+#: src/features/account/AccountReport.tsx
+msgid "Failed to create report for {pkhAddress}."
 msgstr ""
 
 #: src/features/snap/components/ReportSnap.tsx
@@ -595,10 +617,6 @@ msgstr ""
 
 #: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
 msgid "has been evaluated as unsecured by your community"
-msgstr ""
-
-#: src/features/account/AccountReport.tsx
-msgid "has been reported"
 msgstr ""
 
 #: src/components/icons/index.ts
@@ -1175,10 +1193,6 @@ msgstr ""
 
 #: src/components/FooterAccountManagementTerms.tsx
 msgid "You will not be able to use your MetaMask Secret Recovery Phrase to recover accounts added through Account Management Snaps. If your account credentials are lost or compromised, MetaMask will not be able to help you. If the Snap or the associated dapp is hacked or ceases to function, you may not be able to access your account and the funds in your account."
-msgstr ""
-
-#: src/features/account/AccountTEEndorsement.tsx
-msgid "Your endorsement has been done"
 msgstr ""
 
 #: src/features/account/components/modals/TEEndorsementModal.tsx

--- a/src/locales/tr-TR/messages.po
+++ b/src/locales/tr-TR/messages.po
@@ -34,6 +34,14 @@ msgstr ""
 msgid "{nameText} Snaps on the MetaMask Snaps Directory"
 msgstr ""
 
+#: src/features/account/AccountTEEndorsement.tsx
+msgid "{pkhAddress} has been endorsed."
+msgstr ""
+
+#: src/features/account/AccountReport.tsx
+msgid "{pkhAddress} has been reported."
+msgstr ""
+
 #: src/features/snap/components/community-sentiment/CommunitySentiment.tsx
 #: src/features/snap/components/community-sentiment/CommunitySentiment.tsx
 #: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
@@ -447,6 +455,10 @@ msgstr ""
 msgid "error"
 msgstr ""
 
+#: src/features/account/AccountReport.tsx
+#: src/features/account/AccountReport.tsx
+#: src/features/account/AccountTEEndorsement.tsx
+#: src/features/account/AccountTEEndorsement.tsx
 #: src/features/account/MoreOptionMenu.tsx
 #: src/features/snap/components/EndorseSnap.tsx
 #: src/features/snap/components/EndorseSnap.tsx
@@ -499,9 +511,19 @@ msgstr ""
 msgid "Failed to copy profile link to clipboard"
 msgstr ""
 
+#: src/features/account/AccountTEEndorsement.tsx
+#: src/features/account/AccountTEEndorsement.tsx
+msgid "Failed to create endorsement for {pkhAddress}."
+msgstr ""
+
 #: src/features/snap/components/EndorseSnap.tsx
 #: src/features/snap/components/EndorseSnap.tsx
 msgid "Failed to create endorsement for {snapName}."
+msgstr ""
+
+#: src/features/account/AccountReport.tsx
+#: src/features/account/AccountReport.tsx
+msgid "Failed to create report for {pkhAddress}."
 msgstr ""
 
 #: src/features/snap/components/ReportSnap.tsx
@@ -595,10 +617,6 @@ msgstr ""
 
 #: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
 msgid "has been evaluated as unsecured by your community"
-msgstr ""
-
-#: src/features/account/AccountReport.tsx
-msgid "has been reported"
 msgstr ""
 
 #: src/components/icons/index.ts
@@ -1175,10 +1193,6 @@ msgstr ""
 
 #: src/components/FooterAccountManagementTerms.tsx
 msgid "You will not be able to use your MetaMask Secret Recovery Phrase to recover accounts added through Account Management Snaps. If your account credentials are lost or compromised, MetaMask will not be able to help you. If the Snap or the associated dapp is hacked or ceases to function, you may not be able to access your account and the funds in your account."
-msgstr ""
-
-#: src/features/account/AccountTEEndorsement.tsx
-msgid "Your endorsement has been done"
 msgstr ""
 
 #: src/features/account/components/modals/TEEndorsementModal.tsx

--- a/src/locales/zh-CN/messages.po
+++ b/src/locales/zh-CN/messages.po
@@ -34,6 +34,14 @@ msgstr ""
 msgid "{nameText} Snaps on the MetaMask Snaps Directory"
 msgstr ""
 
+#: src/features/account/AccountTEEndorsement.tsx
+msgid "{pkhAddress} has been endorsed."
+msgstr ""
+
+#: src/features/account/AccountReport.tsx
+msgid "{pkhAddress} has been reported."
+msgstr ""
+
 #: src/features/snap/components/community-sentiment/CommunitySentiment.tsx
 #: src/features/snap/components/community-sentiment/CommunitySentiment.tsx
 #: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
@@ -447,6 +455,10 @@ msgstr ""
 msgid "error"
 msgstr ""
 
+#: src/features/account/AccountReport.tsx
+#: src/features/account/AccountReport.tsx
+#: src/features/account/AccountTEEndorsement.tsx
+#: src/features/account/AccountTEEndorsement.tsx
 #: src/features/account/MoreOptionMenu.tsx
 #: src/features/snap/components/EndorseSnap.tsx
 #: src/features/snap/components/EndorseSnap.tsx
@@ -499,9 +511,19 @@ msgstr ""
 msgid "Failed to copy profile link to clipboard"
 msgstr ""
 
+#: src/features/account/AccountTEEndorsement.tsx
+#: src/features/account/AccountTEEndorsement.tsx
+msgid "Failed to create endorsement for {pkhAddress}."
+msgstr ""
+
 #: src/features/snap/components/EndorseSnap.tsx
 #: src/features/snap/components/EndorseSnap.tsx
 msgid "Failed to create endorsement for {snapName}."
+msgstr ""
+
+#: src/features/account/AccountReport.tsx
+#: src/features/account/AccountReport.tsx
+msgid "Failed to create report for {pkhAddress}."
 msgstr ""
 
 #: src/features/snap/components/ReportSnap.tsx
@@ -595,10 +617,6 @@ msgstr ""
 
 #: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
 msgid "has been evaluated as unsecured by your community"
-msgstr ""
-
-#: src/features/account/AccountReport.tsx
-msgid "has been reported"
 msgstr ""
 
 #: src/components/icons/index.ts
@@ -1175,10 +1193,6 @@ msgstr ""
 
 #: src/components/FooterAccountManagementTerms.tsx
 msgid "You will not be able to use your MetaMask Secret Recovery Phrase to recover accounts added through Account Management Snaps. If your account credentials are lost or compromised, MetaMask will not be able to help you. If the Snap or the associated dapp is hacked or ceases to function, you may not be able to access your account and the funds in your account."
-msgstr ""
-
-#: src/features/account/AccountTEEndorsement.tsx
-msgid "Your endorsement has been done"
 msgstr ""
 
 #: src/features/account/components/modals/TEEndorsementModal.tsx

--- a/src/pages/account/index.test.tsx
+++ b/src/pages/account/index.test.tsx
@@ -17,7 +17,9 @@ jest.mock('../../hooks/useVerifiableCredential', () => ({
   useVerifiableCredential: () => ({
     signMessage: jest.fn(),
     signError: null,
-    accountVCBuilder: jest.fn(),
+    accountVCBuilder: {
+      getSubjectDid: jest.fn().mockReturnValue(VALID_ACCOUNT_1),
+    },
   }),
 }));
 

--- a/src/pages/account/index.test.tsx
+++ b/src/pages/account/index.test.tsx
@@ -4,8 +4,8 @@ import { useAccount } from 'wagmi';
 
 import AccountProfilePage, { Head } from '.';
 import {
-  render,
   getMockSiteMetadata,
+  render,
   VALID_ACCOUNT_1,
 } from '../../utils/test-utils';
 
@@ -18,7 +18,11 @@ jest.mock('../../hooks/useVerifiableCredential', () => ({
     signMessage: jest.fn(),
     signError: null,
     accountVCBuilder: {
-      getSubjectDid: jest.fn().mockReturnValue(VALID_ACCOUNT_1),
+      // TODO: use `ACCOUNT_1` instead of a full address
+      getSubjectDid: jest
+        .fn()
+        .mockReturnValue('0x6B24aE0ABbeb67058D07b891aF415f288eA57Cc7'),
+      getIssuerDid: jest.fn().mockReturnValue('issuerAddress'),
     },
   }),
 }));

--- a/src/pages/account/index.tsx
+++ b/src/pages/account/index.tsx
@@ -9,7 +9,7 @@ import {
 import { Trans, t } from '@lingui/macro';
 import type { Hex } from '@metamask/utils';
 import { graphql, Link as GatsbyLink, withPrefix } from 'gatsby';
-import type { FunctionComponent } from 'react';
+import { useEffect, type FunctionComponent } from 'react';
 import { useAccount } from 'wagmi';
 
 import banner from '../../assets/images/seo/home.png';
@@ -20,6 +20,8 @@ import {
   AccountReport,
   AccountTEEndorsement,
 } from '../../features/account';
+import { fetchAccountAssertionsForAccountId } from '../../features/account/assertions/api';
+import { useDispatch, useVerifiableCredential } from '../../hooks';
 import { type Fields, parseAddress } from '../../utils';
 import NotFound from '../404';
 
@@ -33,11 +35,21 @@ const AccountPage: FunctionComponent<AccountPageProps> = ({ location }) => {
   const { address: connectedAddress, isConnected } = useAccount();
   const params = new URLSearchParams(location.search);
   const address = parseAddress(params.get('address') as Hex);
+  const { accountVCBuilder } = useVerifiableCredential();
+  const dispatch = useDispatch();
+  useEffect(() => {
+    if (address) {
+      const issuer = accountVCBuilder.getIssuerDid(address);
+      dispatch(fetchAccountAssertionsForAccountId(issuer)).catch((error) =>
+        console.log(error),
+      );
+    }
+  }, [dispatch, accountVCBuilder, address]);
+
+  const isMyAccount = address === connectedAddress;
   if (!address) {
     return <NotFound />;
   }
-
-  const isMyAccount = address === connectedAddress;
 
   return (
     <Box position="relative" data-testid="account-info">

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -3,6 +3,7 @@ import type { NoInfer } from '@reduxjs/toolkit/src/tsHelpers';
 import type { CombinedState, PreloadedState } from 'redux';
 
 // Imported separately to avoid circular dependencies.
+import { accountAssertionsSlice } from '../features/account/assertions/store';
 import { accountProfileSlice } from '../features/account/store';
 import { filterSlice } from '../features/filter/store';
 import { notificationsSlice } from '../features/notifications/store';
@@ -19,6 +20,7 @@ const reducer = combineReducers({
   snapsApi: snapsApi.reducer,
   snapAssertions: snapAssertionsSlice.reducer,
   snapTrustScores: snapTrustScoresSlice.reducer,
+  accountAssertions: accountAssertionsSlice.reducer,
 });
 
 /**


### PR DESCRIPTION
## Description

Integrates the Account assertion creation with the API

### Related ticket

Fixes #59

### Type of change

- [ ] Chore
- [ ] Bug fix
- [X] New feature
- [ ] Documentation update
