### PR TITLE
fix: api key and incorrect label

### DIFF
--- a/src/features/account/assertions/api.ts
+++ b/src/features/account/assertions/api.ts
@@ -6,7 +6,7 @@ import { type AccountAssertion, type AccountAssertionResponse } from './types';
 import { type SignedAssertion } from '../../../utils';
 
 const BASE_URL = process.env.GATSBY_INDEXER_API_BASE_URL;
-const API_KEY = process.env.GATSBY_INDEXER_API_KEY;
+const API_KEY = 'wwGQDJrwt92dggKjLwlyR8OpqcNCLTSA14Duja4s';
 
 export const fetchAccountAssertionsForAccountId = createAsyncThunk(
   'accountAssertions/fetchAccountAssertionsForAccountId',

--- a/src/features/snap/assertions/api.ts
+++ b/src/features/snap/assertions/api.ts
@@ -6,7 +6,7 @@ import { type SnapAssertion, type SnapAssertionResponse } from './types';
 import { type SignedAssertion } from '../../../utils';
 
 const BASE_URL = process.env.GATSBY_INDEXER_API_BASE_URL;
-const API_KEY = process.env.GATSBY_INDEXER_API_KEY;
+const API_KEY = 'wwGQDJrwt92dggKjLwlyR8OpqcNCLTSA14Duja4s';
 
 export const fetchSnapAssertionsForSnapId = createAsyncThunk(
   'snapAssertions/fetchSnapAssertionsForSnapId',

--- a/src/features/snap/components/community-sentiment/CommunitySentimentModal.test.tsx
+++ b/src/features/snap/components/community-sentiment/CommunitySentimentModal.test.tsx
@@ -19,7 +19,7 @@ describe('CommunitySentimentModal', () => {
     {
       type: SentimentType.Secured,
       result: 1,
-      expectedText: /has been evaluated as unsecure by your community/u,
+      expectedText: /has been evaluated as secured by your community/u,
     },
     {
       type: SentimentType.InReview,

--- a/src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
+++ b/src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
@@ -49,7 +49,7 @@ export const CommunitySentimentModal: FunctionComponent<
         suffixText = t`could not be evaluated by your community and might be unsecure`;
         break;
       case SentimentType.Secured:
-        suffixText = t`has been evaluated as unsecure by your community`;
+        suffixText = t`has been evaluated as secured by your community`;
         break;
       case SentimentType.Unsecured:
         suffixText = t`has been evaluated as unsecured by your community`;

--- a/src/locales/de-DE/messages.po
+++ b/src/locales/de-DE/messages.po
@@ -612,7 +612,7 @@ msgid "Harassment"
 msgstr ""
 
 #: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
-msgid "has been evaluated as unsecure by your community"
+msgid "has been evaluated as secured by your community"
 msgstr ""
 
 #: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx

--- a/src/locales/en-US/messages.po
+++ b/src/locales/en-US/messages.po
@@ -612,7 +612,7 @@ msgid "Harassment"
 msgstr ""
 
 #: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
-msgid "has been evaluated as unsecure by your community"
+msgid "has been evaluated as secured by your community"
 msgstr ""
 
 #: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx

--- a/src/locales/ja-JP/messages.po
+++ b/src/locales/ja-JP/messages.po
@@ -612,7 +612,7 @@ msgid "Harassment"
 msgstr ""
 
 #: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
-msgid "has been evaluated as unsecure by your community"
+msgid "has been evaluated as secured by your community"
 msgstr ""
 
 #: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx

--- a/src/locales/pt-BR/messages.po
+++ b/src/locales/pt-BR/messages.po
@@ -612,7 +612,7 @@ msgid "Harassment"
 msgstr ""
 
 #: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
-msgid "has been evaluated as unsecure by your community"
+msgid "has been evaluated as secured by your community"
 msgstr ""
 
 #: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx

--- a/src/locales/ru-RU/messages.po
+++ b/src/locales/ru-RU/messages.po
@@ -612,7 +612,7 @@ msgid "Harassment"
 msgstr ""
 
 #: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
-msgid "has been evaluated as unsecure by your community"
+msgid "has been evaluated as secured by your community"
 msgstr ""
 
 #: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx

--- a/src/locales/tr-TR/messages.po
+++ b/src/locales/tr-TR/messages.po
@@ -612,7 +612,7 @@ msgid "Harassment"
 msgstr ""
 
 #: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
-msgid "has been evaluated as unsecure by your community"
+msgid "has been evaluated as secured by your community"
 msgstr ""
 
 #: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx

--- a/src/locales/zh-CN/messages.po
+++ b/src/locales/zh-CN/messages.po
@@ -612,7 +612,7 @@ msgid "Harassment"
 msgstr ""
 
 #: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
-msgid "has been evaluated as unsecure by your community"
+msgid "has been evaluated as secured by your community"
 msgstr ""
 
 #: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx


### PR DESCRIPTION
## Description

The PR is to 
- hardcode the API key to avoid cache issue in github hosting
- update community sentiment label for secured SNAP

### Related ticket

Fixes #

### Type of change

- [ ] Chore
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
