### PR TITLE
feat: I search a specific user

### DIFF
--- a/src/components/Header.test.tsx
+++ b/src/components/Header.test.tsx
@@ -15,6 +15,6 @@ describe('Header', () => {
       async () => await act(() => render(<Header />)),
     );
 
-    expect(queryByPlaceholderText('Search Snaps')).toBeInTheDocument();
+    expect(queryByPlaceholderText('Search users or snaps')).toBeInTheDocument();
   });
 });

--- a/src/features/account/AccountReport.test.tsx
+++ b/src/features/account/AccountReport.test.tsx
@@ -8,9 +8,9 @@ import {
 } from './assertions/api';
 import { useDispatch, useSelector, useVerifiableCredential } from '../../hooks';
 import {
+  render,
   VALID_ACCOUNT_1,
   VALID_ACCOUNT_2,
-  render,
 } from '../../utils/test-utils';
 
 jest.mock('../../hooks');
@@ -19,6 +19,7 @@ jest.mock('./assertions/api');
 
 jest.mock('wagmi', () => ({
   useEnsName: jest.fn(),
+  createConfig: jest.fn(),
 }));
 
 jest.mock('../../hooks/useVerifiableCredential', () => ({

--- a/src/features/account/AccountTEEndorsement.test.tsx
+++ b/src/features/account/AccountTEEndorsement.test.tsx
@@ -20,6 +20,7 @@ jest.mock('./assertions/api');
 
 jest.mock('wagmi', () => ({
   useEnsName: jest.fn(),
+  createConfig: jest.fn(),
 }));
 
 jest.mock('../../hooks/useVerifiableCredential', () => ({

--- a/src/features/account/MoreOptionMenu.test.tsx
+++ b/src/features/account/MoreOptionMenu.test.tsx
@@ -18,6 +18,7 @@ jest.mock('wagmi', () => ({
       chainId: 1,
     },
   }),
+  createConfig: jest.fn(),
 }));
 
 describe('MoreOptionMenu', () => {

--- a/src/features/account/components/AccountInfo.test.tsx
+++ b/src/features/account/components/AccountInfo.test.tsx
@@ -22,6 +22,7 @@ jest.mock('wagmi', () => ({
       chainId: 1,
     },
   }),
+  createConfig: jest.fn(),
 }));
 
 jest.mock('./AccountRoleTags', () => ({

--- a/src/features/account/components/modals/AddToUserCircleModal.tsx
+++ b/src/features/account/components/modals/AddToUserCircleModal.tsx
@@ -58,9 +58,6 @@ export const AddToUserCircleModal: FunctionComponent<
     signMessage(VC)
       .then((signature) => {
         if (signature) {
-          const assertion = accountVCBuilder.getSignedAssertion(VC, signature);
-          console.log('assertion', assertion);
-
           showSuccessMsg({
             title: t`Added to your trust circle`,
             description: t`${shortSubAddress} has been added to your trust circle`,

--- a/src/features/community/components/AccountCard.test.tsx
+++ b/src/features/community/components/AccountCard.test.tsx
@@ -1,13 +1,9 @@
+import { act } from '@testing-library/react';
 import { useAccount, useEnsName } from 'wagmi';
 
 import { AccountCard } from './AccountCard';
-import { VALID_ACCOUNT_1, render } from '../../../utils/test-utils';
+import { render, VALID_ACCOUNT_1 } from '../../../utils/test-utils';
 import { TrustScoreScope } from '../../account/trust-score/types';
-
-jest.mock('gatsby', () => ({
-  ...jest.requireActual('gatsby'),
-  navigate: jest.fn(),
-}));
 
 jest.mock('wagmi', () => ({
   ...jest.requireActual('wagmi'),
@@ -104,5 +100,33 @@ describe('AccountCard', () => {
 
     expect(queryByText('name [Snap1]')).toBeInTheDocument();
     expect(queryAllByTestId('account-role-tags')).toHaveLength(1);
+  });
+
+  it('calls the default onClick handler when clicked if no onClick handler is provided', async () => {
+    const { getByRole } = await act(() =>
+      render(
+        <AccountCard accountId={mockAccountId} trustScore={mockTrustScore} />,
+      ),
+    );
+
+    expect(() => act(() => getByRole('link').click())).not.toThrow();
+  });
+
+  it('calls the onClick handler when clicked', async () => {
+    const onClick = jest.fn();
+
+    const { getByRole } = await act(() =>
+      render(
+        <AccountCard
+          accountId={mockAccountId}
+          trustScore={mockTrustScore}
+          onClick={onClick}
+        />,
+      ),
+    );
+
+    act(() => getByRole('link').click());
+
+    expect(onClick).toHaveBeenCalled();
   });
 });

--- a/src/features/community/components/AccountCard.tsx
+++ b/src/features/community/components/AccountCard.tsx
@@ -1,4 +1,4 @@
-import { Flex, Text, Box, Button, Spacer } from '@chakra-ui/react';
+import { Box, Button, Flex, Spacer, Text } from '@chakra-ui/react';
 import { Trans } from '@lingui/macro';
 import { Link } from 'gatsby';
 import type { FunctionComponent } from 'react';
@@ -23,6 +23,7 @@ export const AccountCard: FunctionComponent<AccountCardProps> = ({
   accountId,
   trustScore,
   snapName,
+  onClick = () => undefined,
 }) => {
   const address = (
     accountId.startsWith('0x') ? accountId : accountId.split(':')[4]
@@ -34,7 +35,7 @@ export const AccountCard: FunctionComponent<AccountCardProps> = ({
   const shortAddress = trimAddress(address);
   const title = `${data ?? shortAddress}${snapName ? ` [${snapName}]` : ``}`;
   return (
-    <Link to={`/account/?address=${address}`}>
+    <Link to={`/account/?address=${address}`} onClick={onClick}>
       <Card
         padding="2"
         _hover={{

--- a/src/features/filter/components/FilterSearch.tsx
+++ b/src/features/filter/components/FilterSearch.tsx
@@ -12,6 +12,7 @@ import { useEffect, useState } from 'react';
 
 import { FilterSearchInput } from './FilterSearchInput';
 import { useDispatch, useSearchResults, useSelector } from '../../../hooks';
+import { AccountCard } from '../../community/components';
 import { getSnapsById } from '../../snaps';
 import { SnapCard } from '../../snaps/components';
 import { Order } from '../constants';
@@ -24,8 +25,10 @@ export const FilterSearch: FunctionComponent = () => {
   const dispatch = useDispatch();
 
   const snaps = useSelector(
-    getSnapsById(results.map((result) => result.snapId)),
+    getSnapsById(results.snaps.map((result) => result.snapId)),
   );
+
+  const users = results.users.map((result) => result.address);
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     setQuery(event.target.value);
@@ -50,12 +53,12 @@ export const FilterSearch: FunctionComponent = () => {
   };
 
   useEffect(() => {
-    if (snaps.length > 0) {
+    if (snaps.length > 0 || users.length > 0) {
       return onOpen();
     }
 
     return onClose();
-  }, [snaps.length, query, onOpen, onClose]);
+  }, [snaps.length, users.length, query, onOpen, onClose]);
 
   return (
     <Menu isLazy={true} isOpen={isOpen} onOpen={onOpen} onClose={onClose}>
@@ -66,21 +69,31 @@ export const FilterSearch: FunctionComponent = () => {
         onFormClick={handleClick}
         onFormSubmit={handleAll}
       />
-      <MenuList maxWidth="23.875rem" padding="1" boxShadow="xl">
+      <MenuList
+        minWidth="23.875rem"
+        maxWidth="23.875rem"
+        padding="1"
+        boxShadow="xl"
+      >
         {snaps.slice(0, 5).map((snap) => (
           <SnapCard key={`${snap.snapId}`} {...snap} onClick={onClose} />
         ))}
-        <Link
-          href="#"
-          display="block"
-          fontSize="md"
-          fontWeight="500"
-          textAlign="center"
-          paddingY="4"
-          onClick={handleAll}
-        >
-          <Trans>See all results</Trans>
-        </Link>
+        {users.slice(0, 5).map((user) => (
+          <AccountCard key={`${user}`} accountId={user} onClick={onClose} />
+        ))}
+        {users.length === 0 && (
+          <Link
+            href="#"
+            display="block"
+            fontSize="md"
+            fontWeight="500"
+            textAlign="center"
+            paddingY="4"
+            onClick={handleAll}
+          >
+            <Trans>See all results</Trans>
+          </Link>
+        )}
       </MenuList>
     </Menu>
   );

--- a/src/features/filter/components/FilterSearchInput.test.tsx
+++ b/src/features/filter/components/FilterSearchInput.test.tsx
@@ -15,7 +15,7 @@ describe('FilterSearchInput', () => {
       />,
     );
 
-    const input = getByPlaceholderText('Search Snaps');
+    const input = getByPlaceholderText('Search users or snaps');
     fireEvent.change(input, { target: { value: 'test' } });
 
     expect(onFormChange).toHaveBeenCalledTimes(1);
@@ -32,7 +32,7 @@ describe('FilterSearchInput', () => {
       />,
     );
 
-    const input = getByPlaceholderText('Search Snaps');
+    const input = getByPlaceholderText('Search users or snaps');
     fireEvent.click(input);
 
     expect(onFormClick).toHaveBeenCalledTimes(1);
@@ -49,7 +49,7 @@ describe('FilterSearchInput', () => {
       />,
     );
 
-    const input = getByPlaceholderText('Search Snaps');
+    const input = getByPlaceholderText('Search users or snaps');
     fireEvent.keyDown(input, { key: 'Enter' });
 
     expect(onFormSubmit).toHaveBeenCalledTimes(1);
@@ -66,7 +66,7 @@ describe('FilterSearchInput', () => {
       />,
     );
 
-    const input = getByPlaceholderText('Search Snaps');
+    const input = getByPlaceholderText('Search users or snaps');
     fireEvent.keyDown(input, { key: 'a' });
 
     expect(onFormSubmit).toHaveBeenCalledTimes(0);

--- a/src/features/filter/components/FilterSearchInput.tsx
+++ b/src/features/filter/components/FilterSearchInput.tsx
@@ -38,7 +38,7 @@ export const FilterSearchInput: FunctionComponent<FilterSearchInputProps> =
         <Input
           type="search"
           borderRadius="full"
-          placeholder={t`Search Snaps`}
+          placeholder={t`Search users or snaps`}
           value={query}
           onChange={onFormChange}
           onClick={onFormClick}

--- a/src/features/filter/store.test.ts
+++ b/src/features/filter/store.test.ts
@@ -41,10 +41,10 @@ describe('filterSlice', () => {
       const { snap } = getMockSnap();
       const state = filterSlice.reducer(
         filterSlice.getInitialState(),
-        setSearchResults([{ item: snap }]),
+        setSearchResults({ snaps: [snap], users: [] }),
       );
 
-      expect(state.searchResults).toStrictEqual([{ item: snap }]);
+      expect(state.searchResults).toStrictEqual({ snaps: [snap], users: [] });
     });
   });
 
@@ -60,7 +60,7 @@ describe('filterSlice', () => {
       const newState = filterSlice.reducer(state, resetSearch());
 
       expect(newState.searchQuery).toBe('');
-      expect(newState.searchResults).toStrictEqual([]);
+      expect(newState.searchResults).toStrictEqual({ snaps: [], users: [] });
     });
   });
 
@@ -186,7 +186,7 @@ describe('filterSlice', () => {
         {
           installed: true,
           searchQuery: 'foo',
-          searchResults: [],
+          searchResults: { snaps: [], users: [] },
           categories: [RegistrySnapCategory.Interoperability],
           order: Order.Latest,
         },
@@ -312,7 +312,7 @@ describe('filterSlice', () => {
       const state = getMockState({
         filter: {
           searchQuery: '',
-          searchResults: [],
+          searchResults: { snaps: [], users: [] },
           installed: false,
           categories: [],
           order: Order.Popularity,
@@ -333,7 +333,7 @@ describe('filterSlice', () => {
       const state = getMockState({
         filter: {
           searchQuery: '',
-          searchResults: [],
+          searchResults: { snaps: [], users: [] },
           installed: false,
           categories: [
             RegistrySnapCategory.Interoperability,
@@ -383,7 +383,7 @@ describe('filterSlice', () => {
       const state = getMockState({
         filter: {
           searchQuery: '',
-          searchResults: [],
+          searchResults: { snaps: [], users: [] },
           installed: false,
           categories: [
             RegistrySnapCategory.Interoperability,
@@ -427,7 +427,7 @@ describe('filterSlice', () => {
       const state = getMockState({
         filter: {
           searchQuery: 'foo',
-          searchResults: [fooSnap, barSnap],
+          searchResults: { snaps: [fooSnap, barSnap], users: [] },
           installed: false,
           categories: [
             RegistrySnapCategory.Interoperability,
@@ -467,14 +467,10 @@ describe('filterSlice', () => {
       const state = getMockState({
         filter: {
           searchQuery: '',
-          searchResults: [
-            {
-              item: fooSnap,
-            },
-            {
-              item: barSnap,
-            },
-          ],
+          searchResults: {
+            snaps: [fooSnap, barSnap],
+            users: [],
+          },
           installed: false,
           categories: [
             RegistrySnapCategory.Interoperability,
@@ -512,7 +508,7 @@ describe('filterSlice', () => {
       const state = getMockState({
         filter: {
           searchQuery: '',
-          searchResults: [],
+          searchResults: { snaps: [], users: [] },
           installed: true,
           categories: [
             RegistrySnapCategory.Interoperability,
@@ -557,7 +553,7 @@ describe('filterSlice', () => {
       const state = getMockState({
         filter: {
           searchQuery: '',
-          searchResults: [],
+          searchResults: { snaps: [], users: [] },
           installed: false,
           categories: [
             RegistrySnapCategory.Notifications,
@@ -605,7 +601,7 @@ describe('filterSlice', () => {
       const state = getMockState({
         filter: {
           searchQuery: '',
-          searchResults: [],
+          searchResults: { snaps: [], users: [] },
           installed: false,
           categories: [
             RegistrySnapCategory.Interoperability,
@@ -661,7 +657,7 @@ describe('filterSlice', () => {
       const state = getMockState({
         filter: {
           searchQuery: '',
-          searchResults: [],
+          searchResults: { snaps: [], users: [] },
           installed: false,
           categories: [
             RegistrySnapCategory.Interoperability,
@@ -714,7 +710,7 @@ describe('filterSlice', () => {
       const state = getMockState({
         filter: {
           searchQuery: '',
-          searchResults: [],
+          searchResults: { snaps: [], users: [] },
           installed: false,
           categories: [
             RegistrySnapCategory.Interoperability,
@@ -767,7 +763,7 @@ describe('filterSlice', () => {
       const state = getMockState({
         filter: {
           searchQuery: '',
-          searchResults: [],
+          searchResults: { snaps: [], users: [] },
           installed: false,
           categories: [
             RegistrySnapCategory.Interoperability,
@@ -821,7 +817,7 @@ describe('filterSlice', () => {
       const state = getMockState({
         filter: {
           searchQuery: '',
-          searchResults: [],
+          searchResults: { snaps: [], users: [] },
           installed: false,
           categories: [
             RegistrySnapCategory.Interoperability,

--- a/src/features/filter/store.ts
+++ b/src/features/filter/store.ts
@@ -1,5 +1,6 @@
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSelector, createSlice } from '@reduxjs/toolkit';
+import type { Address } from '@wagmi/core';
 
 import { Order } from './constants';
 import { SORT_FUNCTIONS } from './sort';
@@ -10,7 +11,7 @@ import { getInstalledSnaps, getSnapsById } from '../snaps';
 
 export type FilterState = {
   searchQuery: string;
-  searchResults: Snap[];
+  searchResults: { snaps: Snap[]; users: { address: Address }[] };
   installed: boolean;
   categories: RegistrySnapCategory[];
   order: Order;
@@ -22,7 +23,7 @@ const INITIAL_CATEGORIES = Object.values(
 
 const initialState: FilterState = {
   searchQuery: '',
-  searchResults: [],
+  searchResults: { snaps: [], users: [] },
   installed: false,
   categories: INITIAL_CATEGORIES,
   order: Order.Popularity,
@@ -35,12 +36,15 @@ export const filterSlice = createSlice({
     setSearchQuery: (state, action: PayloadAction<string>) => {
       state.searchQuery = action.payload;
     },
-    setSearchResults: (state, action: PayloadAction<Snap[]>) => {
+    setSearchResults: (
+      state,
+      action: PayloadAction<{ snaps: Snap[]; users: { address: Address }[] }>,
+    ) => {
       state.searchResults = action.payload;
     },
     resetSearch: (state) => {
       state.searchQuery = '';
-      state.searchResults = [];
+      state.searchResults = { snaps: [], users: [] };
     },
     filterAll: (state) => {
       state.installed = false;
@@ -141,7 +145,7 @@ export const getFilteredSnaps = createSelector(
 
     const searchedSnaps =
       searchQuery.length > 0
-        ? getSnapsById(searchResults.map((snap) => snap.snapId))(state)
+        ? getSnapsById(searchResults.snaps.map((snap) => snap.snapId))(state)
         : snaps;
 
     const sortedSnaps = SORT_FUNCTIONS[order](searchedSnaps);

--- a/src/hooks/useVerifiableCredential.test.ts
+++ b/src/hooks/useVerifiableCredential.test.ts
@@ -22,6 +22,7 @@ jest.mock('wagmi', () => ({
   usePublicClient: jest.fn(),
   useSignTypedData: jest.fn(),
   useChainId: () => 1,
+  createConfig: jest.fn(),
 }));
 
 describe('useVerifiableCredential', () => {

--- a/src/locales/de-DE/messages.po
+++ b/src/locales/de-DE/messages.po
@@ -917,7 +917,7 @@ msgid "Search"
 msgstr ""
 
 #: src/features/filter/components/FilterSearchInput.tsx
-msgid "Search Snaps"
+msgid "Search users or snaps"
 msgstr ""
 
 #: src/components/icons/index.ts

--- a/src/locales/en-US/messages.po
+++ b/src/locales/en-US/messages.po
@@ -917,7 +917,7 @@ msgid "Search"
 msgstr ""
 
 #: src/features/filter/components/FilterSearchInput.tsx
-msgid "Search Snaps"
+msgid "Search users or snaps"
 msgstr ""
 
 #: src/components/icons/index.ts

--- a/src/locales/ja-JP/messages.po
+++ b/src/locales/ja-JP/messages.po
@@ -917,7 +917,7 @@ msgid "Search"
 msgstr ""
 
 #: src/features/filter/components/FilterSearchInput.tsx
-msgid "Search Snaps"
+msgid "Search users or snaps"
 msgstr ""
 
 #: src/components/icons/index.ts

--- a/src/locales/pt-BR/messages.po
+++ b/src/locales/pt-BR/messages.po
@@ -917,7 +917,7 @@ msgid "Search"
 msgstr ""
 
 #: src/features/filter/components/FilterSearchInput.tsx
-msgid "Search Snaps"
+msgid "Search users or snaps"
 msgstr ""
 
 #: src/components/icons/index.ts

--- a/src/locales/ru-RU/messages.po
+++ b/src/locales/ru-RU/messages.po
@@ -917,7 +917,7 @@ msgid "Search"
 msgstr ""
 
 #: src/features/filter/components/FilterSearchInput.tsx
-msgid "Search Snaps"
+msgid "Search users or snaps"
 msgstr ""
 
 #: src/components/icons/index.ts

--- a/src/locales/tr-TR/messages.po
+++ b/src/locales/tr-TR/messages.po
@@ -917,7 +917,7 @@ msgid "Search"
 msgstr ""
 
 #: src/features/filter/components/FilterSearchInput.tsx
-msgid "Search Snaps"
+msgid "Search users or snaps"
 msgstr ""
 
 #: src/components/icons/index.ts

--- a/src/locales/zh-CN/messages.po
+++ b/src/locales/zh-CN/messages.po
@@ -917,7 +917,7 @@ msgid "Search"
 msgstr ""
 
 #: src/features/filter/components/FilterSearchInput.tsx
-msgid "Search Snaps"
+msgid "Search users or snaps"
 msgstr ""
 
 #: src/components/icons/index.ts

--- a/src/pages/account/index.test.tsx
+++ b/src/pages/account/index.test.tsx
@@ -45,6 +45,7 @@ jest.mock('wagmi', () => ({
     },
     loading: false,
   }),
+  createConfig: jest.fn(),
 }));
 
 jest.mock('@chakra-ui/react', () => ({

--- a/src/pages/snap/{Snap.location}/{Snap.slug}.test.tsx
+++ b/src/pages/snap/{Snap.location}/{Snap.slug}.test.tsx
@@ -4,9 +4,9 @@ import { useAccount } from 'wagmi';
 
 import SnapPage, { Head } from './{Snap.slug}';
 import {
-  render,
   getMockSiteMetadata,
   getMockSnap,
+  render,
   VALID_ACCOUNT_1,
 } from '../../../utils/test-utils';
 
@@ -24,6 +24,7 @@ jest.mock('../../../hooks/useVerifiableCredential', () => ({
 
 jest.mock('wagmi', () => ({
   useAccount: jest.fn(),
+  createConfig: jest.fn(),
 }));
 
 describe('Snap page', () => {

--- a/src/utils/address.test.ts
+++ b/src/utils/address.test.ts
@@ -7,6 +7,10 @@ jest.mock('viem', () => ({
   getAddress: jest.fn(),
 }));
 
+jest.mock('wagmi', () => ({
+  createConfig: jest.fn(),
+}));
+
 describe('parseAddress', () => {
   let mockGetAddress: jest.Mock;
 


### PR DESCRIPTION
## Description

Adds a way to search for a user via the usual search bar:
- Matching on exact ETH address
- Matching on exact ENS name

Currently working for exact ETH address:

https://github.com/MetaMask/permissionless-snaps-directory/assets/5815882/c63e2648-e169-466f-a0c3-f781eb7f934f

### Related ticket

Fixes [#20](https://app.zenhub.com/workspaces/snaps-permissionless-distribution-652446543fea3f1af2ecafbf/issues/gh/metamask/permissionless-snaps/20)

### Type of change

- [ ] Chore
- [ ] Bug fix
- [X] New feature
- [ ] Documentation update
