### PR TITLE
fix: Close modals when clicking on the overlay

### DIFF
--- a/src/components/SimpleModal.tsx
+++ b/src/components/SimpleModal.tsx
@@ -36,7 +36,6 @@ export const SimpleModal: FunctionComponent<SimpleModalProps> = ({
       size="sm"
       isOpen={isOpen}
       onClose={onClose}
-      closeOnOverlayClick={false}
       {...props}
     >
       <ModalOverlay />


### PR DESCRIPTION
## Description

Closes modals when clicking on the overlay

### Type of change

- [ ] Chore
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
