### PR TITLE
feat: Show Top Authors section in Community page

### DIFF
--- a/src/features/account/trust-score/store.test.ts
+++ b/src/features/account/trust-score/store.test.ts
@@ -10,6 +10,7 @@ import {
   getAccountsTrustScores,
   getAccountTrustScoreForAccountId,
   getTopAccountsForScope,
+  getTopAuthors,
 } from './store';
 import { TrustScoreScope } from './types';
 import { type ApplicationState } from '../../../store';
@@ -271,5 +272,27 @@ describe('Selectors', () => {
       // Expect the selector to return an empty array
       expect(topSoftwareDevelopers).toStrictEqual([]);
     });
+  });
+});
+
+describe('getTopAuthors', () => {
+  it('returns an array of top authors with the correct structure', () => {
+    const topAuthors = getTopAuthors();
+
+    // Check if the returned value is an array
+    expect(Array.isArray(topAuthors)).toBe(true);
+
+    // Check if each author has the correct structure
+    topAuthors.forEach((author) => {
+      expect(author).toHaveProperty('accountId');
+      expect(author).toHaveProperty('snapName');
+    });
+  });
+
+  it('returns the correct number of top authors', () => {
+    const topAuthors = getTopAuthors();
+
+    // Check if the returned array contains 6 authors
+    expect(topAuthors).toHaveLength(6);
   });
 });

--- a/src/features/account/trust-score/store.ts
+++ b/src/features/account/trust-score/store.ts
@@ -105,3 +105,32 @@ export const getTopAccountsForScope = (
         )
         .slice(0, topCounter), // Getting the top counter accounts
   );
+
+export const getTopAuthors = () => {
+  return [
+    {
+      accountId: '0x17FA0A61bf1719D12C08c61F211A063a58267A19',
+      snapName: 'WalletChat',
+    },
+    {
+      accountId: '0x34998e5b7Ad419618A9071E73Edb5C4332D9201D',
+      snapName: 'Blockfence',
+    },
+    {
+      accountId: '0xC63caBe93bB29c61E337a87B2E3d4D7C5F5556c0',
+      snapName: 'EAS',
+    },
+    {
+      accountId: '0x34312D7Ccc11486bb725428773D5Def8371c689B',
+      snapName: 'Tuum Tech',
+    },
+    {
+      accountId: '0xA1e08A6379c3d50CAC89AeE0bc020abA7FA16099',
+      snapName: 'Masca',
+    },
+    {
+      accountId: '0xA43c3Cbe0476eEA16ee135bE4646c7A5423E812e',
+      snapName: 'Wallet Guard',
+    },
+  ];
+};

--- a/src/features/community/CommunityList.test.tsx
+++ b/src/features/community/CommunityList.test.tsx
@@ -57,7 +57,7 @@ describe('CommunityList', () => {
     const { queryAllByTestId } = render(<CommunityList />);
 
     expect(queryAllByTestId('account-card')).toHaveLength(
-      mockTopDevelopers.length,
+      mockTopDevelopers.length + 6, // 6 is the number of authors hardcoded
     );
   });
 
@@ -68,7 +68,7 @@ describe('CommunityList', () => {
     const { queryAllByTestId } = render(<CommunityList />);
 
     expect(queryAllByTestId('account-card')).toHaveLength(
-      mockTopAuditors.length,
+      mockTopAuditors.length + 6, // 6 is the number of authors hardcoded
     );
   });
 });

--- a/src/features/community/CommunityList.tsx
+++ b/src/features/community/CommunityList.tsx
@@ -4,7 +4,10 @@ import type { FunctionComponent } from 'react';
 
 import { AccountCard } from './components';
 import { useSelector } from '../../hooks';
-import { getTopAccountsForScope } from '../account/trust-score/store';
+import {
+  getTopAccountsForScope,
+  getTopAuthors,
+} from '../account/trust-score/store';
 import { TrustScoreScope } from '../account/trust-score/types';
 
 export const CommunityList: FunctionComponent = () => {
@@ -14,6 +17,7 @@ export const CommunityList: FunctionComponent = () => {
   const topAuditors = useSelector(
     getTopAccountsForScope(9, TrustScoreScope.SoftwareSecurity),
   );
+  const topAuthors = getTopAuthors();
 
   return (
     <>
@@ -39,6 +43,19 @@ export const CommunityList: FunctionComponent = () => {
             key={`${auditor.accountId}-${index}`}
             accountId={auditor.accountId}
             trustScore={auditor}
+          ></AccountCard>
+        ))}
+      </SimpleGrid>
+      <Divider my="8" />
+      <Heading as="h2" fontSize="2xl" marginBottom={8}>
+        <Trans>Top Community Authors</Trans>
+      </Heading>
+      <SimpleGrid columns={[1, null, 2, 3]} spacing={4}>
+        {topAuthors.map((authors, index) => (
+          <AccountCard
+            key={`${authors.accountId}-${index}`}
+            accountId={authors.accountId}
+            snapName={authors.snapName}
           ></AccountCard>
         ))}
       </SimpleGrid>

--- a/src/features/community/CommunityList.tsx
+++ b/src/features/community/CommunityList.tsx
@@ -47,7 +47,7 @@ export const CommunityList: FunctionComponent = () => {
         ))}
       </SimpleGrid>
       <Divider my="8" />
-      <Heading as="h2" fontSize="2xl" marginBottom={8}>
+      <Heading as="h2" fontSize="2xl" mb={8}>
         <Trans>Top Community Authors</Trans>
       </Heading>
       <SimpleGrid columns={[1, null, 2, 3]} spacing={4}>

--- a/src/features/community/components/AccountCard.test.tsx
+++ b/src/features/community/components/AccountCard.test.tsx
@@ -20,6 +20,10 @@ jest.mock('wagmi', () => ({
   }),
 }));
 
+jest.mock('../../account/components/AccountRoleTags', () => ({
+  AccountRoleTags: () => <div data-testid="account-role-tags" />,
+}));
+
 describe('AccountCard', () => {
   const mockTrustScore = {
     accountId: 'accountId',
@@ -47,22 +51,58 @@ describe('AccountCard', () => {
   const mockAccountId = `did:pkh:eip155:1:${VALID_ACCOUNT_1}`;
 
   it('renders the account card correctly', () => {
-    const { queryByText } = render(
+    const { queryByText, queryAllByTestId } = render(
       <AccountCard accountId={mockAccountId} trustScore={mockTrustScore} />,
     );
 
     expect(queryByText('name')).toBeInTheDocument();
     expect(queryByText('View')).toBeInTheDocument();
+    expect(queryAllByTestId('account-role-tags')).toHaveLength(1);
   });
 
   it('renders the account card correctly when ens name does not exist', () => {
     mockUseEnsName.mockImplementation(() => ({
       isLoading: false,
     }));
-    const { queryByText } = render(
+    const { queryAllByTestId } = render(
       <AccountCard accountId={mockAccountId} trustScore={mockTrustScore} />,
     );
 
-    expect(queryByText('Developer')).toBeInTheDocument();
+    expect(queryAllByTestId('account-role-tags')).toHaveLength(1);
+  });
+
+  it('renders the account card without AccountRoleTags if trustscore is not provided', () => {
+    const { queryAllByTestId } = render(
+      <AccountCard accountId={mockAccountId} />,
+    );
+
+    expect(queryAllByTestId('account-role-tags')).toHaveLength(0);
+  });
+
+  it('renders the account card with snap name', () => {
+    const { queryAllByTestId, queryByText } = render(
+      <AccountCard
+        accountId={mockAccountId}
+        trustScore={mockTrustScore}
+        snapName="Snap1"
+      />,
+    );
+
+    expect(queryByText('name [Snap1]')).toBeInTheDocument();
+    expect(queryAllByTestId('account-role-tags')).toHaveLength(1);
+  });
+
+  it('renders the account card with accountId starting with 0x', () => {
+    const accountIdStartingWith0x = VALID_ACCOUNT_1;
+    const { queryAllByTestId, queryByText } = render(
+      <AccountCard
+        accountId={accountIdStartingWith0x}
+        trustScore={mockTrustScore}
+        snapName="Snap1"
+      />,
+    );
+
+    expect(queryByText('name [Snap1]')).toBeInTheDocument();
+    expect(queryAllByTestId('account-role-tags')).toHaveLength(1);
   });
 });

--- a/src/features/community/components/AccountCard.tsx
+++ b/src/features/community/components/AccountCard.tsx
@@ -14,21 +14,25 @@ import {
 
 export type AccountCardProps = {
   accountId: string;
-  trustScore: AccountTrustScore;
+  trustScore?: AccountTrustScore;
+  snapName?: string;
   onClick?: () => void;
 };
 
 export const AccountCard: FunctionComponent<AccountCardProps> = ({
   accountId,
   trustScore,
+  snapName,
 }) => {
-  const address = accountId.split(':')[4] as Hex;
+  const address = (
+    accountId.startsWith('0x') ? accountId : accountId.split(':')[4]
+  ) as Hex;
   const { data } = useEnsName({
     address,
     chainId: mainnet.id,
   });
   const shortAddress = trimAddress(address);
-  const title = data ?? shortAddress;
+  const title = `${data ?? shortAddress}${snapName ? ` [${snapName}]` : ``}`;
   return (
     <Link to={`/account/?address=${address}`}>
       <Card
@@ -61,7 +65,7 @@ export const AccountCard: FunctionComponent<AccountCardProps> = ({
           </Button>
         </Flex>
       </Card>
-      <AccountRoleTags trustScores={[trustScore]} />
+      {trustScore && <AccountRoleTags trustScores={[trustScore]} />}
     </Link>
   );
 };

--- a/src/locales/de-DE/messages.po
+++ b/src/locales/de-DE/messages.po
@@ -1116,6 +1116,10 @@ msgid "Toggle color mode"
 msgstr ""
 
 #: src/features/community/CommunityList.tsx
+msgid "Top Community Authors"
+msgstr ""
+
+#: src/features/community/CommunityList.tsx
 msgid "Top Community Developers"
 msgstr ""
 

--- a/src/locales/en-US/messages.po
+++ b/src/locales/en-US/messages.po
@@ -1116,6 +1116,10 @@ msgid "Toggle color mode"
 msgstr ""
 
 #: src/features/community/CommunityList.tsx
+msgid "Top Community Authors"
+msgstr ""
+
+#: src/features/community/CommunityList.tsx
 msgid "Top Community Developers"
 msgstr ""
 

--- a/src/locales/ja-JP/messages.po
+++ b/src/locales/ja-JP/messages.po
@@ -1116,6 +1116,10 @@ msgid "Toggle color mode"
 msgstr ""
 
 #: src/features/community/CommunityList.tsx
+msgid "Top Community Authors"
+msgstr ""
+
+#: src/features/community/CommunityList.tsx
 msgid "Top Community Developers"
 msgstr ""
 

--- a/src/locales/pt-BR/messages.po
+++ b/src/locales/pt-BR/messages.po
@@ -1116,6 +1116,10 @@ msgid "Toggle color mode"
 msgstr ""
 
 #: src/features/community/CommunityList.tsx
+msgid "Top Community Authors"
+msgstr ""
+
+#: src/features/community/CommunityList.tsx
 msgid "Top Community Developers"
 msgstr ""
 

--- a/src/locales/ru-RU/messages.po
+++ b/src/locales/ru-RU/messages.po
@@ -1116,6 +1116,10 @@ msgid "Toggle color mode"
 msgstr ""
 
 #: src/features/community/CommunityList.tsx
+msgid "Top Community Authors"
+msgstr ""
+
+#: src/features/community/CommunityList.tsx
 msgid "Top Community Developers"
 msgstr ""
 

--- a/src/locales/tr-TR/messages.po
+++ b/src/locales/tr-TR/messages.po
@@ -1116,6 +1116,10 @@ msgid "Toggle color mode"
 msgstr ""
 
 #: src/features/community/CommunityList.tsx
+msgid "Top Community Authors"
+msgstr ""
+
+#: src/features/community/CommunityList.tsx
 msgid "Top Community Developers"
 msgstr ""
 

--- a/src/locales/zh-CN/messages.po
+++ b/src/locales/zh-CN/messages.po
@@ -1116,6 +1116,10 @@ msgid "Toggle color mode"
 msgstr ""
 
 #: src/features/community/CommunityList.tsx
+msgid "Top Community Authors"
+msgstr ""
+
+#: src/features/community/CommunityList.tsx
 msgid "Top Community Developers"
 msgstr ""
 


### PR DESCRIPTION
## Description

Added new section Top Authors in Community page

<img width="1033" alt="image" src="https://github.com/MetaMask/permissionless-snaps-directory/assets/77279246/4b4663ca-36d2-4009-85d9-804d1019c25c">


### Related ticket

Fixes #58 

### Type of change

- [ ] Chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
