### PR TITLE
chore: Change the "assertions by subject" API endpoint

### DIFF
--- a/src/features/account/assertions/api.ts
+++ b/src/features/account/assertions/api.ts
@@ -12,7 +12,9 @@ export const fetchAccountAssertionsForAccountId = createAsyncThunk(
   'accountAssertions/fetchAccountAssertionsForAccountId',
   async (accountId: string) => {
     try {
-      const response = await axios.get(`${BASE_URL}/assertions/${accountId}`);
+      const response = await axios.get(
+        `${BASE_URL}/assertions/subjects/${accountId}`,
+      );
       return { accountId, assertions: response.data.assertions } as {
         accountId: string;
         assertions: AccountAssertion[];


### PR DESCRIPTION
## Description

Changes the API endpoint to get assertions by subject, following this [backend change](https://github.com/MetaMask/permissionless-reputation-indexer/pull/50).

### Type of change

- [X] Chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
