### PR TITLE
feat: AAU, I see the addresses of developers and auditors

### DIFF
--- a/src/features/snap/components/Metadata.test.tsx
+++ b/src/features/snap/components/Metadata.test.tsx
@@ -4,7 +4,13 @@ import { getMockSnap, render } from '../../../utils/test-utils';
 
 jest.mock('../../../hooks');
 jest.mock('./community-sentiment', () => ({
-  CommunitySentiment: () => <div />,
+  CommunitySentiment: () => <div data-testid="community-sentiment" />,
+}));
+jest.mock('./MetadataItems', () => ({
+  MetadataItems: () => <div data-testid="metadata-items" />,
+}));
+jest.mock('./MetadataModal', () => ({
+  MetadataModal: () => <div data-testid="metadata-modal" />,
 }));
 
 describe('Metadata', () => {
@@ -27,16 +33,15 @@ describe('Metadata', () => {
     expect(queryByText('Security')).toBeInTheDocument();
   });
 
-  it('renders the developer', () => {
+  it('renders the metadata items', () => {
     const mockDispatch = jest.fn().mockImplementation(() => ({
       catch: jest.fn(),
     }));
     mockUseDispatch.mockReturnValue(mockDispatch);
 
     const { snap } = getMockSnap();
-    const { queryByText } = render(<Metadata snap={snap} />);
-    expect(queryByText('Developer')).toBeInTheDocument();
-    expect(queryByText('Author')).toBeInTheDocument();
+    const { queryByTestId } = render(<Metadata snap={snap} />);
+    expect(queryByTestId('metadata-items')).toBeInTheDocument();
   });
 
   it('renders the developer even when fetchSnapAssertionsForSnapId fails', () => {
@@ -50,10 +55,11 @@ describe('Metadata', () => {
     );
 
     const { snap } = getMockSnap();
-    const { queryByText } = render(
+    const { queryByTestId } = render(
       <Metadata
         snap={{
           ...snap,
+          privateCode: true,
           support: {
             contact: '',
             faq: '',
@@ -63,7 +69,7 @@ describe('Metadata', () => {
       />,
     );
 
-    expect(queryByText('Developer')).toBeInTheDocument();
+    expect(queryByTestId('metadata-items')).toBeInTheDocument();
   });
 
   it('renders the key recovery link', () => {

--- a/src/features/snap/components/Metadata.tsx
+++ b/src/features/snap/components/Metadata.tsx
@@ -1,7 +1,9 @@
-import { Flex, Link, useDisclosure } from '@chakra-ui/react';
+import { Box, Flex, Link, useDisclosure } from '@chakra-ui/react';
 import { t, Trans } from '@lingui/macro';
 import { useEffect, type FunctionComponent } from 'react';
+import type { Hex } from 'viem';
 
+import { Identifier, SourceCode } from '.';
 import { Category } from './Category';
 import { CommunitySentiment } from './community-sentiment';
 import { Data } from './Data';
@@ -50,7 +52,16 @@ export const Metadata: FunctionComponent<MetadataProps> = ({ snap }) => {
     );
   }, [dispatch, snap.latestChecksum]);
 
-  const { category, support } = snap;
+  const {
+    name,
+    author,
+    category,
+    support,
+    sourceCode,
+    additionalSourceCode,
+    privateCode,
+    snapId,
+  } = snap;
 
   return (
     <Flex marginBottom="8" gap="4" justifyContent="space-between">
@@ -65,9 +76,38 @@ export const Metadata: FunctionComponent<MetadataProps> = ({ snap }) => {
             value={<Category category={category as RegistrySnapCategory} />}
           />
         )}
-
-        <MetadataItems snap={snap} />
-        {<CommunitySentiment snap={snap} />}
+        <CommunitySentiment snap={snap} />
+        <Data label={t`Identifier`} value={<Identifier snapId={snapId} />} />
+        {author && <MetadataItems address={author.address as Hex} />}
+        <Data
+          label={t`Source Code`}
+          value={
+            <SourceCode
+              url={sourceCode}
+              additionalUrls={additionalSourceCode}
+            />
+          }
+          warning={
+            privateCode && (
+              <Trans>
+                <Box as="span" fontWeight="500">
+                  {name}
+                </Box>{' '}
+                uses code that isn&apos;t viewable by the public. Critical parts
+                of the codebase were audited for security, but later versions of
+                the code may not be. Make sure you trust{' '}
+                <Box as="span" fontWeight="500">
+                  {author.name}
+                </Box>{' '}
+                before installing and using{' '}
+                <Box as="span" fontWeight="500">
+                  {name}
+                </Box>
+                .
+              </Trans>
+            )
+          }
+        />
         {(support?.contact || support?.faq || support?.knowledgeBase) && (
           <Data
             label={t`Support`}

--- a/src/features/snap/components/MetadataAuditItem.test.tsx
+++ b/src/features/snap/components/MetadataAuditItem.test.tsx
@@ -1,7 +1,7 @@
 import { act } from 'react-dom/test-utils';
 import { useEnsName } from 'wagmi';
 
-import { MetadataItems } from './MetadataItems';
+import { MetadataAuditItem } from './MetadataAuditItem';
 import { VALID_ACCOUNT_1, render } from '../../../utils/test-utils';
 
 jest.mock('wagmi', () => ({
@@ -17,11 +17,11 @@ const buildEnsNameMock = (name?: string, isLoading = false) => {
   }));
 };
 
-describe('MetadataItems', () => {
-  it('renders the developer', async () => {
+describe('MetadataAuditItem', () => {
+  it('renders the auditors', async () => {
     buildEnsNameMock('ens.mock.name');
     const { queryByText, getByText } = render(
-      <MetadataItems address={VALID_ACCOUNT_1} />,
+      <MetadataAuditItem auditorAddresses={[VALID_ACCOUNT_1]} />,
     );
 
     expect(queryByText('ens.mock.name')).toBeInTheDocument();
@@ -31,9 +31,11 @@ describe('MetadataItems', () => {
     await act(async () => link.click());
   });
 
-  it('renders the developer without ens name', () => {
+  it('renders the auditors without ens names', () => {
     buildEnsNameMock(undefined);
-    const { queryByText } = render(<MetadataItems address={VALID_ACCOUNT_1} />);
+    const { queryByText } = render(
+      <MetadataAuditItem auditorAddresses={[VALID_ACCOUNT_1]} />,
+    );
 
     expect(queryByText('ens.mock.name')).not.toBeInTheDocument();
   });

--- a/src/features/snap/components/MetadataAuditItem.tsx
+++ b/src/features/snap/components/MetadataAuditItem.tsx
@@ -1,4 +1,4 @@
-import { Link } from '@chakra-ui/react';
+import { Link } from 'gatsby';
 import { t } from '@lingui/macro';
 import { navigate } from 'gatsby';
 import type { FunctionComponent } from 'react';

--- a/src/features/snap/components/MetadataAuditItem.tsx
+++ b/src/features/snap/components/MetadataAuditItem.tsx
@@ -1,0 +1,49 @@
+import { Link } from '@chakra-ui/react';
+import { t } from '@lingui/macro';
+import { navigate } from 'gatsby';
+import type { FunctionComponent } from 'react';
+import type { Hex } from 'viem';
+import { mainnet, useEnsName } from 'wagmi';
+
+import { Data } from './Data';
+import { trimAddress } from '../../../utils';
+
+export type MetadataAuditItemProps = {
+  auditorAddresses: Hex[];
+};
+
+export const MetadataAuditItem: FunctionComponent<MetadataAuditItemProps> = ({
+  auditorAddresses,
+}) => {
+  const auditors: any[] = [];
+  for (const address of auditorAddresses) {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const { data } = useEnsName({
+      address,
+      chainId: mainnet.id,
+    });
+    auditors.push(data ?? trimAddress(address));
+  }
+  return (
+    <>
+      {auditors.length > 0 && (
+        <Data
+          label={t`Audited By`}
+          value={auditors.map((auditor, index) => (
+            <Link
+              key={`auditor-${index}`}
+              // eslint-disable-next-line @typescript-eslint/no-misused-promises
+              onClick={async () =>
+                navigate(`/account/?address=${auditorAddresses[index]}`, {
+                  replace: true,
+                })
+              }
+            >
+              {auditor}
+            </Link>
+          ))}
+        />
+      )}
+    </>
+  );
+};

--- a/src/features/snap/components/MetadataAuditItem.tsx
+++ b/src/features/snap/components/MetadataAuditItem.tsx
@@ -32,12 +32,7 @@ export const MetadataAuditItem: FunctionComponent<MetadataAuditItemProps> = ({
           value={auditors.map((auditor, index) => (
             <Link
               key={`auditor-${index}`}
-              // eslint-disable-next-line @typescript-eslint/no-misused-promises
-              onClick={async () =>
-                navigate(`/account/?address=${auditorAddresses[index]}`, {
-                  replace: true,
-                })
-              }
+              to={`/account/?address=${auditorAddresses[index]}`}
             >
               {auditor}
             </Link>

--- a/src/features/snap/components/MetadataAuditItem.tsx
+++ b/src/features/snap/components/MetadataAuditItem.tsx
@@ -1,6 +1,6 @@
-import { Link } from 'gatsby';
+import { Text } from '@chakra-ui/react';
 import { t } from '@lingui/macro';
-import { navigate } from 'gatsby';
+import { Link } from 'gatsby';
 import type { FunctionComponent } from 'react';
 import type { Hex } from 'viem';
 import { mainnet, useEnsName } from 'wagmi';
@@ -34,7 +34,7 @@ export const MetadataAuditItem: FunctionComponent<MetadataAuditItemProps> = ({
               key={`auditor-${index}`}
               to={`/account/?address=${auditorAddresses[index]}`}
             >
-              {auditor}
+              <Text color="info.default">{auditor}</Text>
             </Link>
           ))}
         />

--- a/src/features/snap/components/MetadataItems.tsx
+++ b/src/features/snap/components/MetadataItems.tsx
@@ -1,4 +1,4 @@
-import { Link } from '@chakra-ui/react';
+import { Link } from 'gatsby';
 import { t } from '@lingui/macro';
 import { navigate } from 'gatsby';
 import type { FunctionComponent } from 'react';

--- a/src/features/snap/components/MetadataItems.tsx
+++ b/src/features/snap/components/MetadataItems.tsx
@@ -1,6 +1,6 @@
-import { Link } from 'gatsby';
+import { Text } from '@chakra-ui/react';
 import { t } from '@lingui/macro';
-import { navigate } from 'gatsby';
+import { Link } from 'gatsby';
 import type { FunctionComponent } from 'react';
 import type { Hex } from 'viem';
 import { mainnet, useEnsName } from 'wagmi';
@@ -27,6 +27,8 @@ export const MetadataItems: FunctionComponent<MetadataItemsProps> = ({
           label={t`Developer`}
           value={
             <Link to={`/account/?address=${address}`}>
+              <Text color="info.default">{data ?? trimAddress(address)}</Text>
+            </Link>
           }
         />
       )}

--- a/src/features/snap/components/MetadataItems.tsx
+++ b/src/features/snap/components/MetadataItems.tsx
@@ -1,32 +1,44 @@
+import { Link } from '@chakra-ui/react';
 import { t } from '@lingui/macro';
+import { navigate } from 'gatsby';
 import type { FunctionComponent } from 'react';
+import type { Hex } from 'viem';
+import { mainnet, useEnsName } from 'wagmi';
 
 import { Data } from './Data';
-import { Identifier } from './Identifier';
-import { ExternalLink } from '../../../components';
-import type { Fields } from '../../../utils';
+import { trimAddress } from '../../../utils';
 
 export type MetadataItemsProps = {
-  snap: Fields<Queries.Snap, 'snapId' | 'author'>;
+  address: Hex;
 };
 
 export const MetadataItems: FunctionComponent<MetadataItemsProps> = ({
-  snap,
+  address,
 }) => {
-  const { snapId, author } = snap;
+  const { data } = useEnsName({
+    address,
+    chainId: mainnet.id,
+  });
 
   return (
     <>
-      {author && (
+      {address && (
         <Data
           label={t`Developer`}
           value={
-            <ExternalLink href={author.website}>{author.name}</ExternalLink>
+            <Link
+              // eslint-disable-next-line @typescript-eslint/no-misused-promises
+              onClick={async () =>
+                navigate(`/account/?address=${address}`, {
+                  replace: true,
+                })
+              }
+            >
+              {data ?? trimAddress(address)}
+            </Link>
           }
         />
       )}
-
-      <Data label={t`Identifier`} value={<Identifier snapId={snapId} />} />
     </>
   );
 };

--- a/src/features/snap/components/MetadataItems.tsx
+++ b/src/features/snap/components/MetadataItems.tsx
@@ -26,16 +26,7 @@ export const MetadataItems: FunctionComponent<MetadataItemsProps> = ({
         <Data
           label={t`Developer`}
           value={
-            <Link
-              // eslint-disable-next-line @typescript-eslint/no-misused-promises
-              onClick={async () =>
-                navigate(`/account/?address=${address}`, {
-                  replace: true,
-                })
-              }
-            >
-              {data ?? trimAddress(address)}
-            </Link>
+            <Link to={`/account/?address=${address}`}>
           }
         />
       )}

--- a/src/features/snap/components/MetadataModal.test.tsx
+++ b/src/features/snap/components/MetadataModal.test.tsx
@@ -1,20 +1,61 @@
 import { MetadataModal } from './MetadataModal';
+import { useSelector } from '../../../hooks';
 import type { MockSnap } from '../../../utils/test-utils';
 import { getMockSnap, render } from '../../../utils/test-utils';
 
+jest.mock('../../../hooks');
+
+jest.mock('.', () => ({
+  ...jest.requireActual('.'),
+  MetadataAuditItem: () => <div data-testid="metadata-audit-item" />,
+}));
+
+jest.mock('./MetadataItems', () => ({
+  MetadataItems: () => <div data-testid="metadata-items" />,
+}));
+
+jest.mock('./Audits', () => ({
+  Audits: () => <div data-testid="audits" />,
+}));
+
 describe('MetadataModal', () => {
+  let mockUseSelector: jest.Mock;
+
+  beforeEach(() => {
+    mockUseSelector = useSelector as jest.Mock;
+    mockUseSelector.mockClear();
+    mockUseSelector.mockReturnValueOnce([]);
+  });
+
   it('renders', () => {
     const { snap } = getMockSnap();
-    const { queryByText } = render(
+    const { queryByTestId } = render(
       <MetadataModal snap={snap} isOpen={true} onClose={jest.fn()} />,
     );
 
-    expect(queryByText('Developer')).toBeInTheDocument();
+    expect(queryByTestId('metadata-audit-item')).toBeInTheDocument();
+  });
+
+  it('renders without audit', () => {
+    const { snap } = getMockSnap();
+    // @ts-expect-error - We want to test the case where the value is undefined
+    snap.audits = undefined;
+    console.log(snap);
+    const { queryByTestId } = render(
+      <MetadataModal snap={snap} isOpen={true} onClose={jest.fn()} />,
+    );
+
+    expect(queryByTestId('metadata-audit-item')).toBeInTheDocument();
   });
 
   it('renders a warning if the Snap has private code', () => {
     const { snap } = getMockSnap({
       privateCode: true,
+      support: {
+        contact: '',
+        faq: '',
+        knowledgeBase: '',
+      },
     });
 
     const { queryByLabelText } = render(

--- a/src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
+++ b/src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
@@ -1,5 +1,4 @@
 import {
-  Button,
   HStack,
   Tag,
   VStack,
@@ -15,7 +14,6 @@ import { SentimentType } from './types';
 import { getColorForSentiment, getSentimentTypeFromResult } from './utils';
 import {
   CheckFilledShadowIcon,
-  ExternalLinkIcon,
   SignHexagonIcon,
   SimpleModal,
   WarningFilledShadowIcon,
@@ -130,26 +128,6 @@ export const CommunitySentimentModal: FunctionComponent<
                     <Text variant="blue">
                       <Trans>{reportsCount} reports</Trans>
                     </Text>
-                  </HStack>
-                </VStack>
-              </HStack>
-              <HStack>
-                <VStack alignItems="flex-start">
-                  <HStack noOfLines={2}>
-                    <Text>
-                      <Trans>SOURCE CODE</Trans>
-                    </Text>
-                  </HStack>
-                  <HStack>
-                    <Button
-                      variant="link"
-                      fontWeight={'light'}
-                      rightIcon={<ExternalLinkIcon />}
-                    >
-                      <Text variant="blue">
-                        <Trans>GitHub</Trans>
-                      </Text>
-                    </Button>
                   </HStack>
                 </VStack>
               </HStack>

--- a/src/features/snap/components/index.ts
+++ b/src/features/snap/components/index.ts
@@ -5,6 +5,7 @@ export * from './Description';
 export * from './DescriptionText';
 export * from './Identifier';
 export * from './Metadata';
+export * from './MetadataAuditItem';
 export * from './MetadataItems';
 export * from './MetadataModal';
 export * from './Permissions';

--- a/src/features/snap/trust-score/store.test.ts
+++ b/src/features/snap/trust-score/store.test.ts
@@ -60,5 +60,20 @@ describe('Selectors', () => {
 
       expect(snapTrustScoreDetails).toStrictEqual(snapTrustScore);
     });
+
+    it('should return snapTrustScore with result -1 for snapId not available in the state', () => {
+      const snapTrustScore = {
+        snapId: 'snapId',
+        result: -1,
+      };
+      const mockedApplicationState: ApplicationState = mock<ApplicationState>();
+      mockedApplicationState.snapTrustScores.snapTrustScores = [];
+
+      const snapTrustScoreDetails = getSnapTrustScoreForSnapId('snapId')(
+        mockedApplicationState,
+      );
+
+      expect(snapTrustScoreDetails).toStrictEqual(snapTrustScore);
+    });
   });
 });

--- a/src/features/snaps/store.test.ts
+++ b/src/features/snaps/store.test.ts
@@ -1,4 +1,9 @@
+import { mock } from 'ts-mockito';
+
+import { fetchAuditors } from './api';
 import {
+  auditorsSlice,
+  getAuditorAddressesByNames,
   getSnapByChecksum,
   getSnaps,
   getUpdatableSnaps,
@@ -6,6 +11,7 @@ import {
   setSnaps,
   snapsSlice,
 } from './store';
+import type { ApplicationState } from '../../store';
 import {
   getMockQueryResponse,
   getMockSnap,
@@ -218,5 +224,46 @@ describe('snapsSlice', () => {
     });
 
     expect(getSnapByChecksum('foo')(state)).toBeUndefined();
+  });
+});
+
+describe('auditorsSlice reducers', () => {
+  it('should handle fetchAuditors.fulfilled correctly', () => {
+    const initialState = { auditors: null };
+    const action = {
+      type: fetchAuditors.fulfilled.type,
+      payload: [
+        { name: 'Auditor1', address: '0x123' },
+        { name: 'Auditor2', address: '0x456' },
+      ],
+    };
+    const newState = auditorsSlice.reducer(initialState, action);
+    expect(newState.auditors).toStrictEqual([
+      { name: 'Auditor1', address: '0x123' },
+      { name: 'Auditor2', address: '0x456' },
+    ]);
+  });
+});
+
+describe('getAuditorAddressesByNames selector', () => {
+  it('should return an empty array if auditors data is null', () => {
+    const applicationState = mock<ApplicationState>();
+    applicationState.auditors = { auditors: null };
+    const result = getAuditorAddressesByNames(['Auditor1'])(applicationState);
+    expect(result).toStrictEqual([]);
+  });
+
+  it('should return auditor addresses for given names', () => {
+    const applicationState = mock<ApplicationState>();
+    applicationState.auditors = {
+      auditors: [
+        { name: 'Auditor1', address: '0x123' },
+        { name: 'Auditor2', address: '0x456' },
+      ],
+    };
+    const result = getAuditorAddressesByNames(['Auditor1', 'Auditor2'])(
+      applicationState,
+    );
+    expect(result).toStrictEqual(['0x123', '0x456']);
   });
 });

--- a/src/locales/de-DE/messages.po
+++ b/src/locales/de-DE/messages.po
@@ -76,6 +76,7 @@ msgstr ""
 msgid "©{0} MetaMask. All rights reserved."
 msgstr ""
 
+#: src/features/snap/components/Metadata.tsx
 #: src/features/snap/components/MetadataModal.tsx
 msgid "<0>{name}</0> uses code that isn't viewable by the public. Critical parts of the codebase were audited for security, but later versions of the code may not be. Make sure you trust <1>{0}</1> before installing and using <2>{name}</2>."
 msgstr ""
@@ -263,7 +264,11 @@ msgid "and"
 msgstr ""
 
 #: src/features/snap/components/MetadataModal.tsx
-msgid "Audit"
+msgid "Audit Reports"
+msgstr ""
+
+#: src/features/snap/components/MetadataAuditItem.tsx
+msgid "Audited By"
 msgstr ""
 
 #: src/components/icons/index.ts
@@ -340,6 +345,7 @@ msgid "Connect to non-Ethereum blockchains with MetaMask."
 msgstr ""
 
 #: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "Contact"
 msgstr ""
 
@@ -559,6 +565,7 @@ msgid "Failed to verify signature"
 msgstr ""
 
 #: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "FAQ"
 msgstr ""
 
@@ -589,10 +596,6 @@ msgstr ""
 
 #: src/components/FooterLinks.tsx
 msgid "Get in touch"
-msgstr ""
-
-#: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
-msgid "GitHub"
 msgstr ""
 
 #: src/components/icons/index.ts
@@ -644,7 +647,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/features/snap/components/MetadataItems.tsx
+#: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "Identifier"
 msgstr ""
 
@@ -702,10 +706,12 @@ msgid "Key"
 msgstr ""
 
 #: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "Key Recovery"
 msgstr ""
 
 #: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "Knowledge Base"
 msgstr ""
 
@@ -1023,12 +1029,9 @@ msgstr ""
 msgid "Sort"
 msgstr ""
 
+#: src/features/snap/components/Metadata.tsx
 #: src/features/snap/components/MetadataModal.tsx
 msgid "Source Code"
-msgstr ""
-
-#: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
-msgid "SOURCE CODE"
 msgstr ""
 
 #: src/components/icons/index.ts
@@ -1067,6 +1070,7 @@ msgstr ""
 #: src/components/FooterLinks.tsx
 #: src/features/banner/components/faq-banner/FaqBanner.tsx
 #: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "Support"
 msgstr ""
 

--- a/src/locales/en-US/messages.po
+++ b/src/locales/en-US/messages.po
@@ -76,6 +76,7 @@ msgstr ""
 msgid "©{0} MetaMask. All rights reserved."
 msgstr ""
 
+#: src/features/snap/components/Metadata.tsx
 #: src/features/snap/components/MetadataModal.tsx
 msgid "<0>{name}</0> uses code that isn't viewable by the public. Critical parts of the codebase were audited for security, but later versions of the code may not be. Make sure you trust <1>{0}</1> before installing and using <2>{name}</2>."
 msgstr ""
@@ -263,7 +264,11 @@ msgid "and"
 msgstr ""
 
 #: src/features/snap/components/MetadataModal.tsx
-msgid "Audit"
+msgid "Audit Reports"
+msgstr ""
+
+#: src/features/snap/components/MetadataAuditItem.tsx
+msgid "Audited By"
 msgstr ""
 
 #: src/components/icons/index.ts
@@ -340,6 +345,7 @@ msgid "Connect to non-Ethereum blockchains with MetaMask."
 msgstr ""
 
 #: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "Contact"
 msgstr ""
 
@@ -559,6 +565,7 @@ msgid "Failed to verify signature"
 msgstr ""
 
 #: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "FAQ"
 msgstr ""
 
@@ -589,10 +596,6 @@ msgstr ""
 
 #: src/components/FooterLinks.tsx
 msgid "Get in touch"
-msgstr ""
-
-#: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
-msgid "GitHub"
 msgstr ""
 
 #: src/components/icons/index.ts
@@ -644,7 +647,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/features/snap/components/MetadataItems.tsx
+#: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "Identifier"
 msgstr ""
 
@@ -702,10 +706,12 @@ msgid "Key"
 msgstr ""
 
 #: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "Key Recovery"
 msgstr ""
 
 #: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "Knowledge Base"
 msgstr ""
 
@@ -1023,12 +1029,9 @@ msgstr ""
 msgid "Sort"
 msgstr ""
 
+#: src/features/snap/components/Metadata.tsx
 #: src/features/snap/components/MetadataModal.tsx
 msgid "Source Code"
-msgstr ""
-
-#: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
-msgid "SOURCE CODE"
 msgstr ""
 
 #: src/components/icons/index.ts
@@ -1067,6 +1070,7 @@ msgstr ""
 #: src/components/FooterLinks.tsx
 #: src/features/banner/components/faq-banner/FaqBanner.tsx
 #: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "Support"
 msgstr ""
 

--- a/src/locales/ja-JP/messages.po
+++ b/src/locales/ja-JP/messages.po
@@ -76,6 +76,7 @@ msgstr ""
 msgid "©{0} MetaMask. All rights reserved."
 msgstr ""
 
+#: src/features/snap/components/Metadata.tsx
 #: src/features/snap/components/MetadataModal.tsx
 msgid "<0>{name}</0> uses code that isn't viewable by the public. Critical parts of the codebase were audited for security, but later versions of the code may not be. Make sure you trust <1>{0}</1> before installing and using <2>{name}</2>."
 msgstr ""
@@ -263,7 +264,11 @@ msgid "and"
 msgstr ""
 
 #: src/features/snap/components/MetadataModal.tsx
-msgid "Audit"
+msgid "Audit Reports"
+msgstr ""
+
+#: src/features/snap/components/MetadataAuditItem.tsx
+msgid "Audited By"
 msgstr ""
 
 #: src/components/icons/index.ts
@@ -340,6 +345,7 @@ msgid "Connect to non-Ethereum blockchains with MetaMask."
 msgstr ""
 
 #: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "Contact"
 msgstr ""
 
@@ -559,6 +565,7 @@ msgid "Failed to verify signature"
 msgstr ""
 
 #: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "FAQ"
 msgstr ""
 
@@ -589,10 +596,6 @@ msgstr ""
 
 #: src/components/FooterLinks.tsx
 msgid "Get in touch"
-msgstr ""
-
-#: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
-msgid "GitHub"
 msgstr ""
 
 #: src/components/icons/index.ts
@@ -644,7 +647,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/features/snap/components/MetadataItems.tsx
+#: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "Identifier"
 msgstr ""
 
@@ -702,10 +706,12 @@ msgid "Key"
 msgstr ""
 
 #: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "Key Recovery"
 msgstr ""
 
 #: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "Knowledge Base"
 msgstr ""
 
@@ -1023,12 +1029,9 @@ msgstr ""
 msgid "Sort"
 msgstr ""
 
+#: src/features/snap/components/Metadata.tsx
 #: src/features/snap/components/MetadataModal.tsx
 msgid "Source Code"
-msgstr ""
-
-#: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
-msgid "SOURCE CODE"
 msgstr ""
 
 #: src/components/icons/index.ts
@@ -1067,6 +1070,7 @@ msgstr ""
 #: src/components/FooterLinks.tsx
 #: src/features/banner/components/faq-banner/FaqBanner.tsx
 #: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "Support"
 msgstr ""
 

--- a/src/locales/pt-BR/messages.po
+++ b/src/locales/pt-BR/messages.po
@@ -76,6 +76,7 @@ msgstr ""
 msgid "©{0} MetaMask. All rights reserved."
 msgstr ""
 
+#: src/features/snap/components/Metadata.tsx
 #: src/features/snap/components/MetadataModal.tsx
 msgid "<0>{name}</0> uses code that isn't viewable by the public. Critical parts of the codebase were audited for security, but later versions of the code may not be. Make sure you trust <1>{0}</1> before installing and using <2>{name}</2>."
 msgstr ""
@@ -263,7 +264,11 @@ msgid "and"
 msgstr ""
 
 #: src/features/snap/components/MetadataModal.tsx
-msgid "Audit"
+msgid "Audit Reports"
+msgstr ""
+
+#: src/features/snap/components/MetadataAuditItem.tsx
+msgid "Audited By"
 msgstr ""
 
 #: src/components/icons/index.ts
@@ -340,6 +345,7 @@ msgid "Connect to non-Ethereum blockchains with MetaMask."
 msgstr ""
 
 #: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "Contact"
 msgstr ""
 
@@ -559,6 +565,7 @@ msgid "Failed to verify signature"
 msgstr ""
 
 #: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "FAQ"
 msgstr ""
 
@@ -589,10 +596,6 @@ msgstr ""
 
 #: src/components/FooterLinks.tsx
 msgid "Get in touch"
-msgstr ""
-
-#: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
-msgid "GitHub"
 msgstr ""
 
 #: src/components/icons/index.ts
@@ -644,7 +647,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/features/snap/components/MetadataItems.tsx
+#: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "Identifier"
 msgstr ""
 
@@ -702,10 +706,12 @@ msgid "Key"
 msgstr ""
 
 #: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "Key Recovery"
 msgstr ""
 
 #: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "Knowledge Base"
 msgstr ""
 
@@ -1023,12 +1029,9 @@ msgstr ""
 msgid "Sort"
 msgstr ""
 
+#: src/features/snap/components/Metadata.tsx
 #: src/features/snap/components/MetadataModal.tsx
 msgid "Source Code"
-msgstr ""
-
-#: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
-msgid "SOURCE CODE"
 msgstr ""
 
 #: src/components/icons/index.ts
@@ -1067,6 +1070,7 @@ msgstr ""
 #: src/components/FooterLinks.tsx
 #: src/features/banner/components/faq-banner/FaqBanner.tsx
 #: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "Support"
 msgstr ""
 

--- a/src/locales/ru-RU/messages.po
+++ b/src/locales/ru-RU/messages.po
@@ -76,6 +76,7 @@ msgstr ""
 msgid "©{0} MetaMask. All rights reserved."
 msgstr ""
 
+#: src/features/snap/components/Metadata.tsx
 #: src/features/snap/components/MetadataModal.tsx
 msgid "<0>{name}</0> uses code that isn't viewable by the public. Critical parts of the codebase were audited for security, but later versions of the code may not be. Make sure you trust <1>{0}</1> before installing and using <2>{name}</2>."
 msgstr ""
@@ -263,7 +264,11 @@ msgid "and"
 msgstr ""
 
 #: src/features/snap/components/MetadataModal.tsx
-msgid "Audit"
+msgid "Audit Reports"
+msgstr ""
+
+#: src/features/snap/components/MetadataAuditItem.tsx
+msgid "Audited By"
 msgstr ""
 
 #: src/components/icons/index.ts
@@ -340,6 +345,7 @@ msgid "Connect to non-Ethereum blockchains with MetaMask."
 msgstr ""
 
 #: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "Contact"
 msgstr ""
 
@@ -559,6 +565,7 @@ msgid "Failed to verify signature"
 msgstr ""
 
 #: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "FAQ"
 msgstr ""
 
@@ -589,10 +596,6 @@ msgstr ""
 
 #: src/components/FooterLinks.tsx
 msgid "Get in touch"
-msgstr ""
-
-#: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
-msgid "GitHub"
 msgstr ""
 
 #: src/components/icons/index.ts
@@ -644,7 +647,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/features/snap/components/MetadataItems.tsx
+#: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "Identifier"
 msgstr ""
 
@@ -702,10 +706,12 @@ msgid "Key"
 msgstr ""
 
 #: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "Key Recovery"
 msgstr ""
 
 #: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "Knowledge Base"
 msgstr ""
 
@@ -1023,12 +1029,9 @@ msgstr ""
 msgid "Sort"
 msgstr ""
 
+#: src/features/snap/components/Metadata.tsx
 #: src/features/snap/components/MetadataModal.tsx
 msgid "Source Code"
-msgstr ""
-
-#: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
-msgid "SOURCE CODE"
 msgstr ""
 
 #: src/components/icons/index.ts
@@ -1067,6 +1070,7 @@ msgstr ""
 #: src/components/FooterLinks.tsx
 #: src/features/banner/components/faq-banner/FaqBanner.tsx
 #: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "Support"
 msgstr ""
 

--- a/src/locales/tr-TR/messages.po
+++ b/src/locales/tr-TR/messages.po
@@ -76,6 +76,7 @@ msgstr ""
 msgid "©{0} MetaMask. All rights reserved."
 msgstr ""
 
+#: src/features/snap/components/Metadata.tsx
 #: src/features/snap/components/MetadataModal.tsx
 msgid "<0>{name}</0> uses code that isn't viewable by the public. Critical parts of the codebase were audited for security, but later versions of the code may not be. Make sure you trust <1>{0}</1> before installing and using <2>{name}</2>."
 msgstr ""
@@ -263,7 +264,11 @@ msgid "and"
 msgstr ""
 
 #: src/features/snap/components/MetadataModal.tsx
-msgid "Audit"
+msgid "Audit Reports"
+msgstr ""
+
+#: src/features/snap/components/MetadataAuditItem.tsx
+msgid "Audited By"
 msgstr ""
 
 #: src/components/icons/index.ts
@@ -340,6 +345,7 @@ msgid "Connect to non-Ethereum blockchains with MetaMask."
 msgstr ""
 
 #: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "Contact"
 msgstr ""
 
@@ -559,6 +565,7 @@ msgid "Failed to verify signature"
 msgstr ""
 
 #: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "FAQ"
 msgstr ""
 
@@ -589,10 +596,6 @@ msgstr ""
 
 #: src/components/FooterLinks.tsx
 msgid "Get in touch"
-msgstr ""
-
-#: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
-msgid "GitHub"
 msgstr ""
 
 #: src/components/icons/index.ts
@@ -644,7 +647,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/features/snap/components/MetadataItems.tsx
+#: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "Identifier"
 msgstr ""
 
@@ -702,10 +706,12 @@ msgid "Key"
 msgstr ""
 
 #: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "Key Recovery"
 msgstr ""
 
 #: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "Knowledge Base"
 msgstr ""
 
@@ -1023,12 +1029,9 @@ msgstr ""
 msgid "Sort"
 msgstr ""
 
+#: src/features/snap/components/Metadata.tsx
 #: src/features/snap/components/MetadataModal.tsx
 msgid "Source Code"
-msgstr ""
-
-#: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
-msgid "SOURCE CODE"
 msgstr ""
 
 #: src/components/icons/index.ts
@@ -1067,6 +1070,7 @@ msgstr ""
 #: src/components/FooterLinks.tsx
 #: src/features/banner/components/faq-banner/FaqBanner.tsx
 #: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "Support"
 msgstr ""
 

--- a/src/locales/zh-CN/messages.po
+++ b/src/locales/zh-CN/messages.po
@@ -76,6 +76,7 @@ msgstr ""
 msgid "©{0} MetaMask. All rights reserved."
 msgstr ""
 
+#: src/features/snap/components/Metadata.tsx
 #: src/features/snap/components/MetadataModal.tsx
 msgid "<0>{name}</0> uses code that isn't viewable by the public. Critical parts of the codebase were audited for security, but later versions of the code may not be. Make sure you trust <1>{0}</1> before installing and using <2>{name}</2>."
 msgstr ""
@@ -263,7 +264,11 @@ msgid "and"
 msgstr ""
 
 #: src/features/snap/components/MetadataModal.tsx
-msgid "Audit"
+msgid "Audit Reports"
+msgstr ""
+
+#: src/features/snap/components/MetadataAuditItem.tsx
+msgid "Audited By"
 msgstr ""
 
 #: src/components/icons/index.ts
@@ -340,6 +345,7 @@ msgid "Connect to non-Ethereum blockchains with MetaMask."
 msgstr ""
 
 #: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "Contact"
 msgstr ""
 
@@ -559,6 +565,7 @@ msgid "Failed to verify signature"
 msgstr ""
 
 #: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "FAQ"
 msgstr ""
 
@@ -589,10 +596,6 @@ msgstr ""
 
 #: src/components/FooterLinks.tsx
 msgid "Get in touch"
-msgstr ""
-
-#: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
-msgid "GitHub"
 msgstr ""
 
 #: src/components/icons/index.ts
@@ -644,7 +647,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/features/snap/components/MetadataItems.tsx
+#: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "Identifier"
 msgstr ""
 
@@ -702,10 +706,12 @@ msgid "Key"
 msgstr ""
 
 #: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "Key Recovery"
 msgstr ""
 
 #: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "Knowledge Base"
 msgstr ""
 
@@ -1023,12 +1029,9 @@ msgstr ""
 msgid "Sort"
 msgstr ""
 
+#: src/features/snap/components/Metadata.tsx
 #: src/features/snap/components/MetadataModal.tsx
 msgid "Source Code"
-msgstr ""
-
-#: src/features/snap/components/community-sentiment/CommunitySentimentModal.tsx
-msgid "SOURCE CODE"
 msgstr ""
 
 #: src/components/icons/index.ts
@@ -1067,6 +1070,7 @@ msgstr ""
 #: src/components/FooterLinks.tsx
 #: src/features/banner/components/faq-banner/FaqBanner.tsx
 #: src/features/snap/components/Metadata.tsx
+#: src/features/snap/components/MetadataModal.tsx
 msgid "Support"
 msgstr ""
 

--- a/src/pages/index.test.tsx
+++ b/src/pages/index.test.tsx
@@ -2,10 +2,53 @@ import { describe } from '@jest/globals';
 import { useStaticQuery } from 'gatsby';
 
 import IndexPage, { Head } from '.';
+import { useDispatch } from '../hooks';
 import { render, getMock, getMockSiteMetadata } from '../utils/test-utils';
 
+jest.mock('../hooks');
+
 describe('Index page', () => {
+  let mockUseDispatch: jest.Mock;
+  const mockDispatch = jest.fn();
+  beforeEach(() => {
+    mockUseDispatch = useDispatch as jest.Mock;
+    mockUseDispatch.mockClear();
+    mockUseDispatch.mockReturnValue(mockDispatch);
+  });
+
   it('renders', async () => {
+    mockDispatch.mockImplementationOnce(async () =>
+      Promise.resolve({
+        type: 'fulfilled',
+      }),
+    );
+    mockDispatch.mockImplementationOnce(async () =>
+      Promise.resolve({
+        type: 'fulfilled',
+      }),
+    );
+    const mock = getMock(useStaticQuery);
+    mock.mockReturnValue({
+      fusejs: {},
+    });
+
+    const { queryByText } = render(
+      <IndexPage data={{ allSnap: { nodes: [] } }} />,
+    );
+
+    expect(queryByText('Most Popular')).toBeInTheDocument();
+  });
+
+  it('renders when fetchAuditors fails', async () => {
+    mockDispatch.mockImplementationOnce(async () =>
+      Promise.resolve({
+        type: 'fulfilled',
+      }),
+    );
+    mockDispatch.mockImplementationOnce(async () =>
+      Promise.reject(new Error('Unknown error')),
+    );
+
     const mock = getMock(useStaticQuery);
     mock.mockReturnValue({
       fusejs: {},

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,7 +7,12 @@ import { useEffect, type FunctionComponent, Fragment } from 'react';
 import banner from '../assets/images/seo/home.png';
 import { PermissionlessIntroductory } from '../components/PermissionlessIntroductory';
 import { RegistrySnapCategory, SNAP_CATEGORY_LINKS } from '../constants';
-import { Banner, FilteredSnaps, resetFilters } from '../features';
+import {
+  Banner,
+  FilteredSnaps,
+  fetchAuditors,
+  resetFilters,
+} from '../features';
 import { Order } from '../features/filter/constants';
 import { useDispatch } from '../hooks';
 import type { Fields } from '../utils';
@@ -79,6 +84,7 @@ const IndexPage: FunctionComponent<IndexPageProps> = ({ data }) => {
 
   useEffect(() => {
     dispatch(resetFilters());
+    dispatch(fetchAuditors()).catch((error) => console.log(error));
   }, [dispatch]);
 
   return (

--- a/src/pages/snap/{Snap.location}/{Snap.slug}.test.tsx
+++ b/src/pages/snap/{Snap.location}/{Snap.slug}.test.tsx
@@ -10,6 +10,11 @@ import {
   VALID_ACCOUNT_1,
 } from '../../../utils/test-utils';
 
+jest.mock('../../../features', () => ({
+  ...jest.requireActual('../../../features'),
+  Metadata: () => <div data-testid="metadata" />,
+}));
+
 jest.mock('../../../hooks/useVerifiableCredential', () => ({
   ...jest.requireActual('../../../hooks/useVerifiableCredential'),
   useVerifiableCredential: () => ({

--- a/src/pages/snap/{Snap.location}/{Snap.slug}.tsx
+++ b/src/pages/snap/{Snap.location}/{Snap.slug}.tsx
@@ -208,6 +208,7 @@ export const query = graphql`
       onboard
       category
       author {
+        address
         name
         website
       }

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -11,10 +11,11 @@ import { notificationsSlice } from '../features/notifications/store';
 import { snapAssertionsSlice } from '../features/snap/assertions/store';
 import { snapTrustScoresSlice } from '../features/snap/trust-score/store';
 import { snapsApi } from '../features/snaps/api';
-import { snapsSlice } from '../features/snaps/store';
+import { auditorsSlice, snapsSlice } from '../features/snaps/store';
 
 const reducer = combineReducers({
   accountProfile: accountProfileSlice.reducer,
+  auditors: auditorsSlice.reducer,
   filter: filterSlice.reducer,
   notifications: notificationsSlice.reducer,
   snaps: snapsSlice.reducer,


### PR DESCRIPTION
## Description
This PR adds authors and developers addresses on Snap metadata page
### Related ticket

Fixes #84 

### Type of change

- [ ] Chore
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
