### PR TITLE
feat: AAU, I visualize and endorse a user technical expertise

### DIFF
--- a/src/components/EntityName.test.tsx
+++ b/src/components/EntityName.test.tsx
@@ -1,12 +1,12 @@
 import { act } from '@testing-library/react';
 
-import { ActivitySubject } from './ActivitySubject';
-import { useVerifiableCredential } from '../../../../hooks';
-import { createStore } from '../../../../store';
-import { getMockSnap, render } from '../../../../utils/test-utils';
+import { EntityName } from './EntityName';
+import { useVerifiableCredential } from '../hooks';
+import { createStore } from '../store';
+import { getMockSnap, render } from '../utils/test-utils';
 
-jest.mock('../../../../hooks', () => ({
-  ...jest.requireActual('../../../../hooks'),
+jest.mock('../hooks', () => ({
+  ...jest.requireActual('../hooks'),
   useVerifiableCredential: jest.fn(),
 }));
 
@@ -54,7 +54,7 @@ describe('ActivitySubject', () => {
     });
 
     const { queryByText } = await act(async () =>
-      render(<ActivitySubject subject={snapSubject} />, store),
+      render(<EntityName subject={snapSubject} />, store),
     );
 
     expect(queryByText('foo-snap')).toBeInTheDocument();
@@ -85,7 +85,7 @@ describe('ActivitySubject', () => {
     });
 
     const { queryByText } = await act(async () =>
-      render(<ActivitySubject subject={snapSubject} />, store),
+      render(<EntityName subject={snapSubject} />, store),
     );
 
     expect(queryByText('Unknown')).toBeInTheDocument();
@@ -93,9 +93,17 @@ describe('ActivitySubject', () => {
 
   it('renders an account subject with ENS', async () => {
     const { queryByText } = await act(async () =>
-      render(<ActivitySubject subject={peerSubject} />),
+      render(<EntityName subject={peerSubject} />),
     );
 
     expect(queryByText('test.eth')).toBeInTheDocument();
+  });
+
+  it('renders pre-specified title', async () => {
+    const { queryByText } = await act(async () =>
+      render(<EntityName subject={peerSubject} title={'cool title'} />),
+    );
+
+    expect(queryByText('cool title')).toBeInTheDocument();
   });
 });

--- a/src/components/EntityName.tsx
+++ b/src/components/EntityName.tsx
@@ -7,16 +7,18 @@ import type { FunctionComponent } from 'react';
 import { useCallback, useMemo } from 'react';
 import { useEnsName } from 'wagmi';
 
-import { useSelector, useVerifiableCredential } from '../../../../hooks';
-import { truncateAddress } from '../../../../utils';
-import { getSnapByChecksum } from '../../../snaps';
+import { getSnapByChecksum } from '../features';
+import { useSelector, useVerifiableCredential } from '../hooks';
+import { trimAddress } from '../utils';
 
 export type ActivitySubjectProps = {
   subject: string;
+  title?: string;
 };
 
-export const ActivitySubject: FunctionComponent<ActivitySubjectProps> = ({
+export const EntityName: FunctionComponent<ActivitySubjectProps> = ({
   subject,
+  title,
 }) => {
   const { accountVCBuilder, snapVCBuilder } = useVerifiableCredential();
 
@@ -42,14 +44,16 @@ export const ActivitySubject: FunctionComponent<ActivitySubjectProps> = ({
   });
 
   const displaySubject = useCallback(() => {
-    if (isSnap) {
+    if (title) {
+      return title;
+    } else if (isSnap) {
       return snap?.name ?? t`Unknown`;
     } else if (data) {
       return data;
     }
 
-    return truncateAddress(attestedSubject);
-  }, [isSnap, snap, data, attestedSubject]);
+    return attestedSubject ? trimAddress(attestedSubject) : t`Unknown`;
+  }, [title, isSnap, data, attestedSubject, snap?.name]);
 
   const buildLink = useCallback(() => {
     return isSnap
@@ -59,7 +63,9 @@ export const ActivitySubject: FunctionComponent<ActivitySubjectProps> = ({
 
   return (
     <Link to={buildLink()}>
-      <Text color="info.default">{displaySubject()}</Text>
+      <Text color="info.default" ml={-1} mr={-1}>
+        {displaySubject()}
+      </Text>
     </Link>
   );
 };

--- a/src/components/EntityNameWithoutEns.test.tsx
+++ b/src/components/EntityNameWithoutEns.test.tsx
@@ -1,11 +1,11 @@
 import { act } from '@testing-library/react';
 
-import { ActivitySubject } from './ActivitySubject';
-import { useVerifiableCredential } from '../../../../hooks';
-import { render } from '../../../../utils/test-utils';
+import { EntityName } from './EntityName';
+import { useVerifiableCredential } from '../hooks';
+import { render } from '../utils/test-utils';
 
-jest.mock('../../../../hooks', () => ({
-  ...jest.requireActual('../../../../hooks'),
+jest.mock('../hooks', () => ({
+  ...jest.requireActual('../hooks'),
   useVerifiableCredential: jest.fn(),
 }));
 
@@ -20,7 +20,7 @@ jest.mock('wagmi', () => ({
 const peerSubject =
   'did:pkh:eip155:1:0x04bC337f14ad1F7ED42A03f89C5e44eF1cE792f9';
 
-describe('ActivitySubject without ENS', () => {
+describe('EntityName without ENS', () => {
   let mockUseVerifiableCredential: jest.Mock;
 
   beforeEach(() => {
@@ -40,9 +40,25 @@ describe('ActivitySubject without ENS', () => {
 
   it('renders an account subject without ENS', async () => {
     const { queryByText } = await act(async () =>
-      render(<ActivitySubject subject={peerSubject} />),
+      render(<EntityName subject={peerSubject} />),
     );
 
-    expect(queryByText('0x04bC••••92f9')).toBeInTheDocument();
+    expect(queryByText('0x04bC3...792f9')).toBeInTheDocument();
+  });
+
+  it('renders an account subject without ENS and no address', async () => {
+    mockUseVerifiableCredential.mockReturnValue({
+      accountVCBuilder: {
+        getAddressFromDid: jest.fn().mockReturnValue(undefined),
+      },
+      snapVCBuilder: {
+        getSnapIdFromDid: jest.fn().mockReturnValue('mockChecksumFoo'),
+      },
+    });
+    const { queryByText } = await act(async () =>
+      render(<EntityName subject={peerSubject} />),
+    );
+
+    expect(queryByText('Unknown')).toBeInTheDocument();
   });
 });

--- a/src/features/account/AccountTEEndorsement.tsx
+++ b/src/features/account/AccountTEEndorsement.tsx
@@ -1,7 +1,8 @@
 import { t } from '@lingui/macro';
 import type { Hex } from '@metamask/utils';
+import type { Address } from '@wagmi/core';
 import { mainnet } from '@wagmi/core/chains';
-import { useMemo, useState, type FunctionComponent, useEffect } from 'react';
+import { type FunctionComponent, useEffect, useMemo, useState } from 'react';
 import { useEnsName } from 'wagmi';
 
 import {
@@ -20,13 +21,13 @@ import useToastMsg from '../../hooks/useToastMsg';
 import { useVerifiableCredential } from '../../hooks/useVerifiableCredential';
 import {
   trimAddress,
-  TrustworthinessScope,
   type Trustworthiness,
+  TrustworthinessScope,
 } from '../../utils';
 
 type AccountTEEndorsementProps = {
   address: Hex;
-  connectedAddress: Hex;
+  connectedAddress: Address;
 };
 
 export const AccountTEEndorsement: FunctionComponent<
@@ -40,7 +41,7 @@ export const AccountTEEndorsement: FunctionComponent<
   const { signMessage, signError, accountVCBuilder } =
     useVerifiableCredential();
 
-  const trimedAddress = useMemo(() => trimAddress(address), [address]);
+  const trimmedAddress = useMemo(() => trimAddress(address), [address]);
 
   const pkhAddress = accountVCBuilder.getSubjectDid(address);
   const issuer = accountVCBuilder.getSubjectDid(connectedAddress);
@@ -53,7 +54,7 @@ export const AccountTEEndorsement: FunctionComponent<
     isAccountEndorsedByIssuer(pkhAddress, issuer),
   );
 
-  const trustEntity = data ?? trimedAddress;
+  const trustEntity = data ?? trimmedAddress;
 
   const [showModal, setShowModal] = useState(false);
   const [endorsed, setEndorsed] = useState(isAccountEndorsed);

--- a/src/features/account/assertions/store.test.ts
+++ b/src/features/account/assertions/store.test.ts
@@ -14,6 +14,7 @@ import {
   getCurrentTrustworthinessLevelForIssuer,
   getIssuedAssertions,
   getIssuedAssertionsForIssuerId,
+  getTechnicalEndorsementsForAccountId,
   isAccountEndorsedByIssuer,
   isAccountReportedByIssuer,
 } from './store';
@@ -307,6 +308,77 @@ describe('Selectors', () => {
         endorsementsCount: 1,
         reportsCount: 1,
       });
+    });
+  });
+
+  describe('getTechnicalEndorsementsForAccountId', () => {
+    it('should return technical endorsements for a specific accountId', () => {
+      const earlierDate = new Date('2022-01-01');
+      const middleDate = new Date('2022-01-02');
+      const laterDate = new Date('2022-01-03');
+      const accountAssertion1: AccountAssertionState = {
+        accountId: 'accountId',
+        issuer: 'issuer',
+        trustworthiness: [
+          { level: 1, scope: TrustworthinessScope.SoftwareDevelopment },
+        ],
+        creationAt: earlierDate, // Earlier date
+      };
+      const accountAssertion2: AccountAssertionState = {
+        accountId: 'accountId',
+        issuer: 'issuer',
+        trustworthiness: [
+          { level: 1, scope: TrustworthinessScope.SoftwareDevelopment },
+        ],
+        creationAt: middleDate, // Middle date
+      };
+      const accountAssertion3: AccountAssertionState = {
+        accountId: 'accountId',
+        issuer: 'issuer',
+        trustworthiness: [
+          { level: 1, scope: TrustworthinessScope.UserExperienceDesign },
+        ],
+        creationAt: laterDate, // Later date
+      };
+      const accountAssertion4: AccountAssertionState = {
+        accountId: 'accountId',
+        issuer: 'issuer',
+        trustworthiness: [
+          { level: 1, scope: TrustworthinessScope.SoftwareSecurity },
+        ],
+        creationAt: laterDate, // Later date
+      };
+      const accountAssertion5: AccountAssertionState = {
+        accountId: 'accountId',
+        issuer: 'issuer',
+        trustworthiness: [
+          { level: -1, scope: TrustworthinessScope.SoftwareSecurity },
+        ],
+        creationAt: laterDate, // Later date
+      };
+      const mockedApplicationState: ApplicationState = mock<ApplicationState>();
+      mockedApplicationState.accountAssertions.accountAssertions = [
+        accountAssertion1,
+        accountAssertion2,
+        accountAssertion3,
+        accountAssertion4,
+        accountAssertion5,
+      ];
+
+      const accountAssertionDetails = getTechnicalEndorsementsForAccountId(
+        'accountId',
+      )(mockedApplicationState);
+
+      expect(accountAssertionDetails).toStrictEqual([
+        {
+          type: TrustworthinessScope.SoftwareDevelopment,
+          endorsements: [accountAssertion1, accountAssertion2],
+        },
+        {
+          type: TrustworthinessScope.SoftwareSecurity,
+          endorsements: [accountAssertion4],
+        },
+      ]);
     });
   });
 

--- a/src/features/account/components/activity/ActivityItem.test.tsx
+++ b/src/features/account/components/activity/ActivityItem.test.tsx
@@ -11,8 +11,8 @@ jest.mock('../../../../hooks', () => ({
   useVerifiableCredential: jest.fn(),
 }));
 
-jest.mock('./ActivitySubject', () => ({
-  ActivitySubject: () => <div data-testid="activity-subject" />,
+jest.mock('../../../../components/EntityName', () => ({
+  EntityName: () => <div data-testid="entity-name" />,
 }));
 
 const snapAssertion: AccountAssertionState = {
@@ -40,7 +40,7 @@ describe('ActivityItem', () => {
       render(<ActivityItem assertion={snapAssertion} />),
     );
 
-    expect(queryByTestId('activity-subject')).toBeInTheDocument();
+    expect(queryByTestId('entity-name')).toBeInTheDocument();
   });
 
   it('renders a snap report activity item', async () => {
@@ -52,7 +52,7 @@ describe('ActivityItem', () => {
       render(<ActivityItem assertion={snapAssertion} />),
     );
 
-    expect(queryByTestId('activity-subject')).toBeInTheDocument();
+    expect(queryByTestId('entity-name')).toBeInTheDocument();
   });
 
   it('renders a peer endorsement activity item', async () => {
@@ -60,7 +60,7 @@ describe('ActivityItem', () => {
       render(<ActivityItem assertion={peerAssertion} />),
     );
 
-    expect(queryByTestId('activity-subject')).toBeInTheDocument();
+    expect(queryByTestId('entity-name')).toBeInTheDocument();
   });
 
   it('renders a peer report activity item', async () => {
@@ -72,7 +72,7 @@ describe('ActivityItem', () => {
       render(<ActivityItem assertion={peerAssertion} />),
     );
 
-    expect(queryByTestId('activity-subject')).toBeInTheDocument();
+    expect(queryByTestId('entity-name')).toBeInTheDocument();
   });
 
   it('renders an activity item even without knowing its type', async () => {
@@ -83,7 +83,7 @@ describe('ActivityItem', () => {
     );
 
     expect(queryByText('Unknown activity')).toBeInTheDocument();
-    expect(queryByTestId('activity-subject')).toBeInTheDocument();
+    expect(queryByTestId('entity-name')).toBeInTheDocument();
   });
 
   it('renders a snap activity item even without knowing its reason', async () => {
@@ -94,7 +94,7 @@ describe('ActivityItem', () => {
       render(<ActivityItem assertion={snapAssertion} />),
     );
 
-    expect(queryByTestId('activity-subject')).toBeInTheDocument();
+    expect(queryByTestId('entity-name')).toBeInTheDocument();
   });
 
   it('renders a peer activity item even without its reason', async () => {
@@ -105,7 +105,7 @@ describe('ActivityItem', () => {
     );
 
     expect(queryByText('for')).not.toBeInTheDocument();
-    expect(queryByTestId('activity-subject')).toBeInTheDocument();
+    expect(queryByTestId('entity-name')).toBeInTheDocument();
   });
 
   it('renders an activity item even with multiple reasons', async () => {
@@ -133,6 +133,6 @@ describe('ActivityItem', () => {
         `for ${TrustworthinessScope.Honesty}, ${TrustworthinessScope.SoftwareDevelopment} and ${TrustworthinessScope.SoftwareSecurity}`,
       ),
     ).toBeInTheDocument();
-    expect(queryByTestId('activity-subject')).toBeInTheDocument();
+    expect(queryByTestId('entity-name')).toBeInTheDocument();
   });
 });

--- a/src/features/account/components/activity/ActivityItem.tsx
+++ b/src/features/account/components/activity/ActivityItem.tsx
@@ -4,12 +4,12 @@ import { formatDistanceToNow } from 'date-fns';
 import type { FunctionComponent } from 'react';
 import { useCallback, useMemo } from 'react';
 
-import { ActivitySubject } from './ActivitySubject';
 import {
   QuestionIcon,
   StarFilledIcon,
   WarningIcon,
 } from '../../../../components';
+import { EntityName } from '../../../../components/EntityName';
 import type { AccountAssertionState } from '../../assertions/store';
 
 export type ActivityItemProps = {
@@ -100,7 +100,7 @@ export const ActivityItem: FunctionComponent<ActivityItemProps> = ({
     <HStack mb={4} width={'100%'} justifyContent={'space-between'}>
       <HStack>
         <Text>{type()}</Text>
-        <ActivitySubject subject={assertion.accountId} />
+        <EntityName subject={assertion.accountId} />
         <Text>{reason()}</Text>
       </HStack>
       <Box alignContent={'flex-end'}>

--- a/src/features/account/components/technical-expertise/TechnicalExpertiseItem.test.tsx
+++ b/src/features/account/components/technical-expertise/TechnicalExpertiseItem.test.tsx
@@ -1,0 +1,147 @@
+import { act } from '@testing-library/react';
+
+import { TechnicalExpertiseItem } from './TechnicalExpertiseItem';
+import { createStore } from '../../../../store';
+import { render, VALID_ACCOUNT_1 } from '../../../../utils/test-utils';
+import { TrustworthinessScope } from '../../assertions/types';
+
+jest.mock('../../../../components/EntityName', () => ({
+  EntityName: () => <div data-testid="entity-name" />,
+}));
+
+describe('TechnicalExpertiseItem', () => {
+  it('renders a set of endorsements', async () => {
+    const store = createStore();
+
+    const { queryAllByTestId } = await act(async () =>
+      render(
+        <TechnicalExpertiseItem
+          endorsements={[
+            {
+              accountId: 'accountId',
+              issuer: 'issuer1',
+              creationAt: new Date(),
+              issuanceDate: new Date(),
+            },
+            {
+              accountId: 'accountId',
+              issuer: 'issuer2',
+              creationAt: new Date(),
+              issuanceDate: new Date(),
+            },
+            {
+              accountId: 'accountId',
+              issuer: `did:pkh:eip155:1:${VALID_ACCOUNT_1}`,
+              creationAt: new Date(),
+              issuanceDate: new Date(),
+            },
+          ]}
+          type={TrustworthinessScope.SoftwareSecurity}
+          myDid={`did:pkh:eip155:1:${VALID_ACCOUNT_1}`}
+        />,
+        store,
+      ),
+    );
+
+    expect(queryAllByTestId('entity-name')).toHaveLength(3);
+  });
+
+  it('renders a single endorsement', async () => {
+    const store = createStore();
+
+    const { queryAllByTestId, queryByText } = await act(async () =>
+      render(
+        <TechnicalExpertiseItem
+          endorsements={[
+            {
+              accountId: 'accountId',
+              issuer: `did:pkh:eip155:1:${VALID_ACCOUNT_1}`,
+              creationAt: new Date(),
+              issuanceDate: new Date(),
+            },
+          ]}
+          type={TrustworthinessScope.SoftwareSecurity}
+          myDid={`did:pkh:eip155:1:${VALID_ACCOUNT_1}`}
+        />,
+        store,
+      ),
+    );
+
+    expect(queryAllByTestId('entity-name')).toHaveLength(1);
+    expect(queryByText(',')).not.toBeInTheDocument();
+  });
+
+  it('renders an endorsement made by the connected user', async () => {
+    const store = createStore();
+
+    const { queryAllByTestId, getByText } = await act(async () =>
+      render(
+        <TechnicalExpertiseItem
+          endorsements={[
+            {
+              accountId: 'accountId',
+              issuer: VALID_ACCOUNT_1,
+              creationAt: new Date(),
+              issuanceDate: new Date(),
+            },
+            {
+              accountId: 'accountId',
+              issuer: 'issuer2',
+              creationAt: new Date(),
+              issuanceDate: new Date(),
+            },
+          ]}
+          type={TrustworthinessScope.SoftwareSecurity}
+          myDid={`did:pkh:eip155:1:${VALID_ACCOUNT_1}`}
+        />,
+        store,
+      ),
+    );
+
+    expect(queryAllByTestId('entity-name')).toHaveLength(2);
+    expect(getByText(',')).toBeInTheDocument();
+  });
+
+  it('renders extra-numerous endorsements', async () => {
+    const store = createStore();
+
+    const { queryAllByTestId, getByText } = await act(async () =>
+      render(
+        <TechnicalExpertiseItem
+          endorsements={[
+            {
+              accountId: 'accountId',
+              issuer: VALID_ACCOUNT_1,
+              creationAt: new Date(),
+              issuanceDate: new Date(),
+            },
+            {
+              accountId: 'accountId',
+              issuer: 'issuer2',
+              creationAt: new Date(),
+              issuanceDate: new Date(),
+            },
+            {
+              accountId: 'accountId',
+              issuer: 'issuer3',
+              creationAt: new Date(),
+              issuanceDate: new Date(),
+            },
+            {
+              accountId: 'accountId',
+              issuer: 'issuer4',
+              creationAt: new Date(),
+              issuanceDate: new Date(),
+            },
+          ]}
+          type={TrustworthinessScope.SoftwareSecurity}
+          myDid={`did:pkh:eip155:1:${VALID_ACCOUNT_1}`}
+        />,
+        store,
+      ),
+    );
+
+    expect(queryAllByTestId('entity-name')).toHaveLength(3);
+    expect(getByText('+ 1 more')).toBeInTheDocument();
+  });
+});

--- a/src/features/account/components/technical-expertise/TechnicalExpertiseItem.tsx
+++ b/src/features/account/components/technical-expertise/TechnicalExpertiseItem.tsx
@@ -1,0 +1,60 @@
+import { HStack, Text, VStack } from '@chakra-ui/react';
+import { t } from '@lingui/macro';
+import type { FunctionComponent } from 'react';
+
+import { EntityName } from '../../../../components/EntityName';
+import type { AccountAssertionState } from '../../assertions/store';
+import type { PKHDid, TrustworthinessScope } from '../../assertions/types';
+
+export type TechnicalExpertiseItemProps = {
+  endorsements: AccountAssertionState[];
+  type: TrustworthinessScope;
+  myDid: PKHDid;
+};
+
+export const TechnicalExpertiseItem: FunctionComponent<
+  TechnicalExpertiseItemProps
+> = ({ endorsements, type, myDid }) => {
+  const isEndorsedByMe = endorsements.find(
+    (endorsement) => endorsement.issuer.toLowerCase() === myDid.toLowerCase(),
+  );
+
+  const endorsementsCount = endorsements.length;
+  const maxEndorsementsToDisplay = Math.min(3, endorsementsCount);
+  const maxEndorsements = isEndorsedByMe
+    ? maxEndorsementsToDisplay - 1
+    : maxEndorsementsToDisplay;
+
+  return (
+    <VStack mb={2} alignItems={'start'}>
+      <Text fontWeight={'medium'}>{type}</Text>
+      <HStack>
+        <Text>{t`Endorsed by`}</Text>
+        {isEndorsedByMe && (
+          <>
+            <EntityName
+              key={`${myDid}-${type}`}
+              subject={myDid}
+              title={`${t`you`}`}
+            />
+            {endorsementsCount > 1 && <Text ml={-1}>,</Text>}
+          </>
+        )}
+        {endorsements.slice(0, maxEndorsements).map((endorsement, index) => (
+          <>
+            <EntityName
+              key={`${endorsement.issuer}-${type}`}
+              subject={endorsement.issuer}
+            />
+            {index < maxEndorsements - 1 && <Text ml={-1}>,</Text>}
+          </>
+        ))}
+        {endorsementsCount > maxEndorsements && (
+          <Text ml={0}>{`+ ${
+            endorsementsCount - maxEndorsements
+          } ${t`more`}`}</Text>
+        )}
+      </HStack>
+    </VStack>
+  );
+};

--- a/src/features/account/components/technical-expertise/TechnicalExpertiseSection.test.tsx
+++ b/src/features/account/components/technical-expertise/TechnicalExpertiseSection.test.tsx
@@ -1,0 +1,109 @@
+import { act } from '@testing-library/react';
+import { getAddress } from 'viem';
+
+import { TechnicalExpertiseSection } from './TechnicalExpertiseSection';
+import { useSelector, useVerifiableCredential } from '../../../../hooks';
+import { createStore } from '../../../../store';
+import { render, VALID_ACCOUNT_1 } from '../../../../utils/test-utils';
+import type { AccountAssertionState } from '../../assertions/store';
+import { TrustworthinessScope } from '../../assertions/types';
+
+jest.mock('../../../../hooks', () => ({
+  ...jest.requireActual('../../../../hooks'),
+  useSelector: jest.fn(),
+  useVerifiableCredential: jest.fn(),
+}));
+
+jest.mock('./TechnicalExpertiseItem', () => ({
+  TechnicalExpertiseItem: () => <div data-testid="technical-expertise-item" />,
+}));
+
+jest.mock('viem', () => ({
+  getAddress: jest.fn(),
+}));
+
+jest.mock('wagmi', () => ({
+  useEnsName: () => ({
+    data: 'test.eth',
+    loading: false,
+  }),
+  createConfig: jest.fn(),
+}));
+
+describe('TechnicalExpertiseSection', () => {
+  let mockUseSelector: jest.Mock;
+  let mockUseVerifiableCredential: jest.Mock;
+  let mockGetAddress: jest.Mock;
+
+  beforeEach(() => {
+    mockUseSelector = useSelector as jest.Mock;
+
+    mockUseVerifiableCredential = useVerifiableCredential as jest.Mock;
+    mockUseVerifiableCredential.mockClear();
+    mockUseVerifiableCredential.mockReturnValue({
+      accountVCBuilder: {
+        getSubjectDid: jest.fn().mockReturnValue('accountId'),
+      },
+    });
+    mockGetAddress = getAddress as jest.Mock;
+    mockGetAddress.mockClear();
+  });
+
+  it('renders technical expertises', async () => {
+    const address = '0x6B24aE0ABbeb67058D07b891aF415f288eA57Cc7';
+    mockGetAddress.mockReturnValue(address);
+    const accountAssertion1: AccountAssertionState = {
+      accountId: 'accountId',
+      issuer: '0xIssuer1',
+      trustworthiness: [
+        { level: 1, scope: TrustworthinessScope.SoftwareDevelopment },
+      ],
+      creationAt: new Date('2022-01-01'),
+    };
+    const accountAssertion2: AccountAssertionState = {
+      accountId: 'accountId',
+      issuer: '0xIssuer2',
+      trustworthiness: [
+        { level: 1, scope: TrustworthinessScope.SoftwareDevelopment },
+      ],
+      creationAt: new Date('2022-01-01'),
+    };
+    const accountAssertion3: AccountAssertionState = {
+      accountId: 'accountId',
+      issuer: '0xIssuer3',
+      trustworthiness: [
+        { level: 1, scope: TrustworthinessScope.SoftwareSecurity },
+      ],
+      creationAt: new Date('2022-01-01'),
+    };
+    mockUseSelector.mockReturnValueOnce([
+      {
+        type: TrustworthinessScope.SoftwareDevelopment,
+        endorsements: [accountAssertion1, accountAssertion2],
+      },
+      {
+        type: TrustworthinessScope.SoftwareSecurity,
+        endorsements: [accountAssertion3],
+      },
+    ]);
+
+    const store = createStore();
+
+    const { queryAllByTestId } = await act(async () =>
+      render(<TechnicalExpertiseSection address={address} />, store),
+    );
+
+    expect(queryAllByTestId('technical-expertise-item')).toHaveLength(2);
+  });
+
+  it('renders an empty section when there is no technical expertise', async () => {
+    const address = VALID_ACCOUNT_1;
+    const store = createStore();
+
+    const { queryByTestId } = await act(async () =>
+      render(<TechnicalExpertiseSection address={address} />, store),
+    );
+
+    expect(queryByTestId('technical-expertise-item')).not.toBeInTheDocument();
+  });
+});

--- a/src/features/account/components/technical-expertise/TechnicalExpertiseSection.tsx
+++ b/src/features/account/components/technical-expertise/TechnicalExpertiseSection.tsx
@@ -1,0 +1,72 @@
+import { Box, Divider, Heading, HStack } from '@chakra-ui/react';
+import { t } from '@lingui/macro';
+import type { Address } from '@wagmi/core';
+import type { FunctionComponent } from 'react';
+import { useMemo } from 'react';
+
+import { TechnicalExpertiseItem } from './TechnicalExpertiseItem';
+import { useSelector, useVerifiableCredential } from '../../../../hooks';
+import { AccountTEEndorsement } from '../../AccountTEEndorsement';
+import { getTechnicalEndorsementsForAccountId } from '../../assertions/store';
+
+export type TechnicalExpertiseSectionProps = {
+  address: Address;
+  connectedAddress?: Address;
+};
+
+export const TechnicalExpertiseSection: FunctionComponent<
+  TechnicalExpertiseSectionProps
+> = ({ address, connectedAddress }) => {
+  const { accountVCBuilder } = useVerifiableCredential();
+  const pkhAddress = useMemo(
+    () => accountVCBuilder.getSubjectDid(address),
+    [accountVCBuilder, address],
+  );
+  const myDid = useMemo(
+    () => accountVCBuilder.getSubjectDid(connectedAddress),
+    [accountVCBuilder, connectedAddress],
+  );
+  const endorsements = useSelector(
+    getTechnicalEndorsementsForAccountId(pkhAddress),
+  );
+
+  const hasEndorsement = endorsements?.some(
+    (endorsementType) => endorsementType.endorsements.length > 0,
+  );
+
+  const isMyAccount = address === connectedAddress;
+
+  return (
+    <>
+      <Divider mt="3rem" mb="2rem" />
+      <HStack
+        mb={4}
+        width={'100%'}
+        justifyContent={'space-between'}
+        alignContent={'center'}
+      >
+        <Heading as="h2" fontSize="2xl">
+          {t`Technical Expertise`}
+        </Heading>
+        {connectedAddress && !isMyAccount && (
+          <AccountTEEndorsement
+            address={address}
+            connectedAddress={connectedAddress}
+          />
+        )}
+      </HStack>
+      {hasEndorsement && (
+        <Box data-testid="activity-section">
+          {endorsements?.map((endorsementType, index) => (
+            <TechnicalExpertiseItem
+              key={`${endorsementType.type}-${index}`}
+              endorsements={endorsementType.endorsements}
+              type={endorsementType.type}
+              myDid={myDid}
+            />
+          ))}
+        </Box>
+      )}
+    </>
+  );
+};

--- a/src/locales/de-DE/messages.po
+++ b/src/locales/de-DE/messages.po
@@ -470,6 +470,10 @@ msgstr ""
 msgid "Endorsed"
 msgstr ""
 
+#: src/features/account/components/technical-expertise/TechnicalExpertiseItem.tsx
+msgid "Endorsed by"
+msgstr ""
+
 #: src/features/snap/components/community-sentiment/utils.ts
 msgid "error"
 msgstr ""
@@ -791,6 +795,10 @@ msgstr ""
 msgid "MetaMask Snaps is in open beta and only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
 msgstr ""
 
+#: src/features/account/components/technical-expertise/TechnicalExpertiseItem.tsx
+msgid "more"
+msgstr ""
+
 #: src/components/icons/index.ts
 msgid "More Options"
 msgstr ""
@@ -1082,6 +1090,10 @@ msgstr ""
 msgid "Tag"
 msgstr ""
 
+#: src/features/account/components/technical-expertise/TechnicalExpertiseSection.tsx
+msgid "Technical Expertise"
+msgstr ""
+
 #: src/features/snap/components/Legal.tsx
 msgid "Terms of Use"
 msgstr ""
@@ -1142,7 +1154,8 @@ msgstr ""
 msgid "Trusted technical abilities"
 msgstr ""
 
-#: src/features/account/components/activity/ActivitySubject.tsx
+#: src/components/EntityName.tsx
+#: src/components/EntityName.tsx
 msgid "Unknown"
 msgstr ""
 
@@ -1242,6 +1255,10 @@ msgstr ""
 
 #: src/components/icons/index.ts
 msgid "Wifi"
+msgstr ""
+
+#: src/features/account/components/technical-expertise/TechnicalExpertiseItem.tsx
+msgid "you"
 msgstr ""
 
 #: src/components/FooterTerms.tsx

--- a/src/locales/en-US/messages.po
+++ b/src/locales/en-US/messages.po
@@ -470,6 +470,10 @@ msgstr ""
 msgid "Endorsed"
 msgstr ""
 
+#: src/features/account/components/technical-expertise/TechnicalExpertiseItem.tsx
+msgid "Endorsed by"
+msgstr ""
+
 #: src/features/snap/components/community-sentiment/utils.ts
 msgid "error"
 msgstr ""
@@ -791,6 +795,10 @@ msgstr ""
 msgid "MetaMask Snaps is in open beta and only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
 msgstr ""
 
+#: src/features/account/components/technical-expertise/TechnicalExpertiseItem.tsx
+msgid "more"
+msgstr ""
+
 #: src/components/icons/index.ts
 msgid "More Options"
 msgstr ""
@@ -1082,6 +1090,10 @@ msgstr ""
 msgid "Tag"
 msgstr ""
 
+#: src/features/account/components/technical-expertise/TechnicalExpertiseSection.tsx
+msgid "Technical Expertise"
+msgstr ""
+
 #: src/features/snap/components/Legal.tsx
 msgid "Terms of Use"
 msgstr ""
@@ -1142,7 +1154,8 @@ msgstr ""
 msgid "Trusted technical abilities"
 msgstr ""
 
-#: src/features/account/components/activity/ActivitySubject.tsx
+#: src/components/EntityName.tsx
+#: src/components/EntityName.tsx
 msgid "Unknown"
 msgstr ""
 
@@ -1242,6 +1255,10 @@ msgstr ""
 
 #: src/components/icons/index.ts
 msgid "Wifi"
+msgstr ""
+
+#: src/features/account/components/technical-expertise/TechnicalExpertiseItem.tsx
+msgid "you"
 msgstr ""
 
 #: src/components/FooterTerms.tsx

--- a/src/locales/ja-JP/messages.po
+++ b/src/locales/ja-JP/messages.po
@@ -470,6 +470,10 @@ msgstr ""
 msgid "Endorsed"
 msgstr ""
 
+#: src/features/account/components/technical-expertise/TechnicalExpertiseItem.tsx
+msgid "Endorsed by"
+msgstr ""
+
 #: src/features/snap/components/community-sentiment/utils.ts
 msgid "error"
 msgstr ""
@@ -791,6 +795,10 @@ msgstr ""
 msgid "MetaMask Snaps is in open beta and only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
 msgstr ""
 
+#: src/features/account/components/technical-expertise/TechnicalExpertiseItem.tsx
+msgid "more"
+msgstr ""
+
 #: src/components/icons/index.ts
 msgid "More Options"
 msgstr ""
@@ -1082,6 +1090,10 @@ msgstr ""
 msgid "Tag"
 msgstr ""
 
+#: src/features/account/components/technical-expertise/TechnicalExpertiseSection.tsx
+msgid "Technical Expertise"
+msgstr ""
+
 #: src/features/snap/components/Legal.tsx
 msgid "Terms of Use"
 msgstr ""
@@ -1142,7 +1154,8 @@ msgstr ""
 msgid "Trusted technical abilities"
 msgstr ""
 
-#: src/features/account/components/activity/ActivitySubject.tsx
+#: src/components/EntityName.tsx
+#: src/components/EntityName.tsx
 msgid "Unknown"
 msgstr ""
 
@@ -1242,6 +1255,10 @@ msgstr ""
 
 #: src/components/icons/index.ts
 msgid "Wifi"
+msgstr ""
+
+#: src/features/account/components/technical-expertise/TechnicalExpertiseItem.tsx
+msgid "you"
 msgstr ""
 
 #: src/components/FooterTerms.tsx

--- a/src/locales/pt-BR/messages.po
+++ b/src/locales/pt-BR/messages.po
@@ -470,6 +470,10 @@ msgstr ""
 msgid "Endorsed"
 msgstr ""
 
+#: src/features/account/components/technical-expertise/TechnicalExpertiseItem.tsx
+msgid "Endorsed by"
+msgstr ""
+
 #: src/features/snap/components/community-sentiment/utils.ts
 msgid "error"
 msgstr ""
@@ -791,6 +795,10 @@ msgstr ""
 msgid "MetaMask Snaps is in open beta and only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
 msgstr ""
 
+#: src/features/account/components/technical-expertise/TechnicalExpertiseItem.tsx
+msgid "more"
+msgstr ""
+
 #: src/components/icons/index.ts
 msgid "More Options"
 msgstr ""
@@ -1082,6 +1090,10 @@ msgstr ""
 msgid "Tag"
 msgstr ""
 
+#: src/features/account/components/technical-expertise/TechnicalExpertiseSection.tsx
+msgid "Technical Expertise"
+msgstr ""
+
 #: src/features/snap/components/Legal.tsx
 msgid "Terms of Use"
 msgstr ""
@@ -1142,7 +1154,8 @@ msgstr ""
 msgid "Trusted technical abilities"
 msgstr ""
 
-#: src/features/account/components/activity/ActivitySubject.tsx
+#: src/components/EntityName.tsx
+#: src/components/EntityName.tsx
 msgid "Unknown"
 msgstr ""
 
@@ -1242,6 +1255,10 @@ msgstr ""
 
 #: src/components/icons/index.ts
 msgid "Wifi"
+msgstr ""
+
+#: src/features/account/components/technical-expertise/TechnicalExpertiseItem.tsx
+msgid "you"
 msgstr ""
 
 #: src/components/FooterTerms.tsx

--- a/src/locales/ru-RU/messages.po
+++ b/src/locales/ru-RU/messages.po
@@ -470,6 +470,10 @@ msgstr ""
 msgid "Endorsed"
 msgstr ""
 
+#: src/features/account/components/technical-expertise/TechnicalExpertiseItem.tsx
+msgid "Endorsed by"
+msgstr ""
+
 #: src/features/snap/components/community-sentiment/utils.ts
 msgid "error"
 msgstr ""
@@ -791,6 +795,10 @@ msgstr ""
 msgid "MetaMask Snaps is in open beta and only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
 msgstr ""
 
+#: src/features/account/components/technical-expertise/TechnicalExpertiseItem.tsx
+msgid "more"
+msgstr ""
+
 #: src/components/icons/index.ts
 msgid "More Options"
 msgstr ""
@@ -1082,6 +1090,10 @@ msgstr ""
 msgid "Tag"
 msgstr ""
 
+#: src/features/account/components/technical-expertise/TechnicalExpertiseSection.tsx
+msgid "Technical Expertise"
+msgstr ""
+
 #: src/features/snap/components/Legal.tsx
 msgid "Terms of Use"
 msgstr ""
@@ -1142,7 +1154,8 @@ msgstr ""
 msgid "Trusted technical abilities"
 msgstr ""
 
-#: src/features/account/components/activity/ActivitySubject.tsx
+#: src/components/EntityName.tsx
+#: src/components/EntityName.tsx
 msgid "Unknown"
 msgstr ""
 
@@ -1242,6 +1255,10 @@ msgstr ""
 
 #: src/components/icons/index.ts
 msgid "Wifi"
+msgstr ""
+
+#: src/features/account/components/technical-expertise/TechnicalExpertiseItem.tsx
+msgid "you"
 msgstr ""
 
 #: src/components/FooterTerms.tsx

--- a/src/locales/tr-TR/messages.po
+++ b/src/locales/tr-TR/messages.po
@@ -470,6 +470,10 @@ msgstr ""
 msgid "Endorsed"
 msgstr ""
 
+#: src/features/account/components/technical-expertise/TechnicalExpertiseItem.tsx
+msgid "Endorsed by"
+msgstr ""
+
 #: src/features/snap/components/community-sentiment/utils.ts
 msgid "error"
 msgstr ""
@@ -791,6 +795,10 @@ msgstr ""
 msgid "MetaMask Snaps is in open beta and only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
 msgstr ""
 
+#: src/features/account/components/technical-expertise/TechnicalExpertiseItem.tsx
+msgid "more"
+msgstr ""
+
 #: src/components/icons/index.ts
 msgid "More Options"
 msgstr ""
@@ -1082,6 +1090,10 @@ msgstr ""
 msgid "Tag"
 msgstr ""
 
+#: src/features/account/components/technical-expertise/TechnicalExpertiseSection.tsx
+msgid "Technical Expertise"
+msgstr ""
+
 #: src/features/snap/components/Legal.tsx
 msgid "Terms of Use"
 msgstr ""
@@ -1142,7 +1154,8 @@ msgstr ""
 msgid "Trusted technical abilities"
 msgstr ""
 
-#: src/features/account/components/activity/ActivitySubject.tsx
+#: src/components/EntityName.tsx
+#: src/components/EntityName.tsx
 msgid "Unknown"
 msgstr ""
 
@@ -1242,6 +1255,10 @@ msgstr ""
 
 #: src/components/icons/index.ts
 msgid "Wifi"
+msgstr ""
+
+#: src/features/account/components/technical-expertise/TechnicalExpertiseItem.tsx
+msgid "you"
 msgstr ""
 
 #: src/components/FooterTerms.tsx

--- a/src/locales/zh-CN/messages.po
+++ b/src/locales/zh-CN/messages.po
@@ -470,6 +470,10 @@ msgstr ""
 msgid "Endorsed"
 msgstr ""
 
+#: src/features/account/components/technical-expertise/TechnicalExpertiseItem.tsx
+msgid "Endorsed by"
+msgstr ""
+
 #: src/features/snap/components/community-sentiment/utils.ts
 msgid "error"
 msgstr ""
@@ -791,6 +795,10 @@ msgstr ""
 msgid "MetaMask Snaps is in open beta and only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
 msgstr ""
 
+#: src/features/account/components/technical-expertise/TechnicalExpertiseItem.tsx
+msgid "more"
+msgstr ""
+
 #: src/components/icons/index.ts
 msgid "More Options"
 msgstr ""
@@ -1082,6 +1090,10 @@ msgstr ""
 msgid "Tag"
 msgstr ""
 
+#: src/features/account/components/technical-expertise/TechnicalExpertiseSection.tsx
+msgid "Technical Expertise"
+msgstr ""
+
 #: src/features/snap/components/Legal.tsx
 msgid "Terms of Use"
 msgstr ""
@@ -1142,7 +1154,8 @@ msgstr ""
 msgid "Trusted technical abilities"
 msgstr ""
 
-#: src/features/account/components/activity/ActivitySubject.tsx
+#: src/components/EntityName.tsx
+#: src/components/EntityName.tsx
 msgid "Unknown"
 msgstr ""
 
@@ -1242,6 +1255,10 @@ msgstr ""
 
 #: src/components/icons/index.ts
 msgid "Wifi"
+msgstr ""
+
+#: src/features/account/components/technical-expertise/TechnicalExpertiseItem.tsx
+msgid "you"
 msgstr ""
 
 #: src/components/FooterTerms.tsx

--- a/src/pages/account/index.tsx
+++ b/src/pages/account/index.tsx
@@ -10,7 +10,6 @@ import banner from '../../assets/images/seo/home.png';
 import {
   AccountInfo,
   AccountReport,
-  AccountTEEndorsement,
   DevelopedSnapsSection,
 } from '../../features/account';
 import {
@@ -18,6 +17,7 @@ import {
   fetchAssertionsByIssuer,
 } from '../../features/account/assertions/api';
 import { ActivitySection } from '../../features/account/components/activity/ActivitySection';
+import { TechnicalExpertiseSection } from '../../features/account/components/technical-expertise/TechnicalExpertiseSection';
 import { fetchTrustScoreForAccountId } from '../../features/account/trust-score/api';
 import { useDispatch, useVerifiableCredential } from '../../hooks';
 import { type Fields, parseAddress } from '../../utils';
@@ -86,20 +86,18 @@ const AccountPage: FunctionComponent<AccountPageProps> = ({ location }) => {
             <AccountInfo address={address} />
             <HStack>
               {isConnected && !isMyAccount && (
-                <>
-                  <AccountReport
-                    address={address}
-                    connectedAddress={connectedAddress as Hex}
-                  />
-                  <AccountTEEndorsement
-                    address={address}
-                    connectedAddress={connectedAddress as Hex}
-                  />
-                </>
+                <AccountReport
+                  address={address}
+                  connectedAddress={connectedAddress as Hex}
+                />
               )}
             </HStack>
           </VStack>
           <DevelopedSnapsSection author={address} />
+          <TechnicalExpertiseSection
+            address={address}
+            connectedAddress={connectedAddress}
+          />
           <ActivitySection address={address} />
         </Container>
       </Box>

--- a/src/utils/address.test.ts
+++ b/src/utils/address.test.ts
@@ -1,6 +1,6 @@
 import { getAddress } from 'viem';
 
-import { parseAddress, truncateAddress } from './address';
+import { parseAddress } from './address';
 import { VALID_ACCOUNT_1 } from './test-utils';
 
 jest.mock('viem', () => ({
@@ -33,15 +33,5 @@ describe('parseAddress', () => {
     });
 
     expect(parseAddress(address)).toBeNull();
-  });
-});
-
-describe('truncateAddress', () => {
-  it('returns address if the address is parsed successfully', async () => {
-    expect(truncateAddress(VALID_ACCOUNT_1)).toBe('0x6B24••••7Cc7');
-  });
-
-  it('returns an empty string if the address is undefined', async () => {
-    expect(truncateAddress(undefined)).toBe('');
   });
 });

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -8,11 +8,3 @@ export const parseAddress = (address: Hex): Hex | null => {
     return null;
   }
 };
-
-export const truncateAddress = (address?: string) =>
-  address
-    ? `${address.slice(0, 6)}••••${address.slice(
-        address.length - 4,
-        address.length,
-      )}`
-    : '';

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -32,7 +32,7 @@ export function trimTextByHeadTail(
 ) {
   const trimmedContent = content.trim();
 
-  // Handle sepcial characters
+  // Handle special characters
   const contentArr = [...trimmedContent];
   if (contentArr.length <= head + tail) {
     return trimmedContent;

--- a/src/utils/verifiable-credential/accountVC.ts
+++ b/src/utils/verifiable-credential/accountVC.ts
@@ -40,7 +40,7 @@ export class AccountVerifiableCredential extends BaseVerifiableCredential {
 
   credentialType = TrustCredentialType.TrustCredential;
 
-  getSubjectDid(subjectAddress: Hex): PKHDid {
+  getSubjectDid(subjectAddress?: Hex): PKHDid {
     return `did:pkh:eip155:${this.chainId}:${subjectAddress}`;
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10348,9 +10348,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001517, caniuse-lite@npm:^1.0.30001520":
-  version: 1.0.30001525
-  resolution: "caniuse-lite@npm:1.0.30001525"
-  checksum: a0d190c185b8e1220dbc72e42f310633059aa175ca3396eb781b249ac3da6c62b30cb8efc5fa24d632cb938f58d90b0c7772d1c9942b6643cf418c27c2cb8632
+  version: 1.0.30001600
+  resolution: "caniuse-lite@npm:1.0.30001600"
+  checksum: 1aae03be0e9f96163e88b9305531ef8db0e01f224aff545c61a32ce0b0ca323e22531bf680bacac3e34f98e23f71ac31a21b328fa0fcbbecea65a2c2638c70c4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

- Moves the 'Endorse' button to the "Technical Expertise" section
- Displays the endorsements of technical expertise

### Related ticket

Fixes #142 

### Type of change

- [ ] Chore
- [ ] Bug fix
- [X] New feature
- [ ] Documentation update
