### PR TITLE
Feat: Add insufficient reviews as default community sentiment

### DIFF
--- a/src/features/snap/components/Metadata.tsx
+++ b/src/features/snap/components/Metadata.tsx
@@ -67,7 +67,7 @@ export const Metadata: FunctionComponent<MetadataProps> = ({ snap }) => {
     <Flex marginBottom="8" gap="4" justifyContent="space-between">
       <MetadataModal snap={snap} isOpen={isOpen} onClose={onClose} />
       <Flex
-        gap={['6', null, null, '16']}
+        gap={['6', null, null, '22']}
         flexDirection={['column', null, null, 'row']}
       >
         {category && (
@@ -76,8 +76,8 @@ export const Metadata: FunctionComponent<MetadataProps> = ({ snap }) => {
             value={<Category category={category as RegistrySnapCategory} />}
           />
         )}
-        <CommunitySentiment snap={snap} />
         <Data label={t`Identifier`} value={<Identifier snapId={snapId} />} />
+        <CommunitySentiment snap={snap} />
         {author && <MetadataItems address={author.address as Hex} />}
         <Data
           label={t`Source Code`}

--- a/src/features/snap/components/community-sentiment/CommunitySentiment.tsx
+++ b/src/features/snap/components/community-sentiment/CommunitySentiment.tsx
@@ -1,11 +1,4 @@
-import {
-  HStack,
-  Link,
-  Tag,
-  TagLabel,
-  VStack,
-  useDisclosure,
-} from '@chakra-ui/react';
+import { Box, Link, Tag, TagLabel, useDisclosure } from '@chakra-ui/react';
 import { Trans, t } from '@lingui/macro';
 import { type FunctionComponent } from 'react';
 
@@ -60,34 +53,22 @@ export const CommunitySentiment: FunctionComponent<CommunitySentimentProps> = ({
 
   const render = () => {
     return (
-      <VStack>
-        <HStack alignSelf={'flex-start'}>
-          <Tag
-            textTransform="none"
-            variant={getColorForSentiment(sentimentType)}
-            onClick={onOpen}
-          >
-            <SignHexagonIcon margin={-1} fill="currentColor"></SignHexagonIcon>
-            <TagLabel>
-              <Trans>{sentimentType}</Trans>
-            </TagLabel>
-          </Tag>
-          {renderLinkLabel(onOpen)}
-        </HStack>
+      <Box>
+        <Tag variant={getColorForSentiment(sentimentType)} onClick={onOpen}>
+          <SignHexagonIcon margin={-1} fill="currentColor"></SignHexagonIcon>
+          <TagLabel>
+            <Trans>{sentimentType}</Trans>
+          </TagLabel>
+        </Tag>
+        {renderLinkLabel(onOpen)}
         <CommunitySentimentModal
           snap={snap}
           isOpen={isOpen}
           onClose={onClose}
         />
-      </VStack>
+      </Box>
     );
   };
 
-  return (
-    sentimentType !== SentimentType.Unknown && (
-      <>
-        <Data label={t`Community Sentiment`} value={render()} />
-      </>
-    )
-  );
+  return <Data label={t`Community Sentiment`} value={render()} />;
 };

--- a/src/features/snap/components/community-sentiment/types.ts
+++ b/src/features/snap/components/community-sentiment/types.ts
@@ -3,5 +3,4 @@ export enum SentimentType {
   Endorsed = 'Endorsed',
   InReview = 'In Review',
   Reported = 'Reported',
-  Unknown = 'Unknown',
 }

--- a/src/features/snap/components/community-sentiment/utils.test.ts
+++ b/src/features/snap/components/community-sentiment/utils.test.ts
@@ -21,8 +21,8 @@ describe('getSentimentTypeFromResult', () => {
     ${1}   | ${SentimentType.Endorsed}
     ${2}   | ${SentimentType.InReview}
     ${3}   | ${SentimentType.Reported}
-    ${4}   | ${SentimentType.Unknown}
-    ${-1}  | ${SentimentType.Unknown}
+    ${4}   | ${SentimentType.InsufficientReview}
+    ${-1}  | ${SentimentType.InsufficientReview}
   `('returns $expectedType for result $result', ({ result, expectedType }) => {
     expect(getSentimentTypeFromResult(result)).toBe(expectedType);
   });

--- a/src/features/snap/components/community-sentiment/utils.ts
+++ b/src/features/snap/components/community-sentiment/utils.ts
@@ -19,8 +19,6 @@ export const getColorForSentiment = (type: SentimentType) => {
 
 export const getSentimentTypeFromResult = (result: number) => {
   switch (result) {
-    case 0:
-      return SentimentType.InsufficientReview;
     case 1:
       return SentimentType.Endorsed;
     case 2:
@@ -28,6 +26,6 @@ export const getSentimentTypeFromResult = (result: number) => {
     case 3:
       return SentimentType.Reported;
     default:
-      return SentimentType.Unknown;
+      return SentimentType.InsufficientReview;
   }
 };


### PR DESCRIPTION
## Description

Add insufficient reviews as default community sentiment

### Related ticket

Fixes #103 

### Type of change

- [ ] Chore
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
