### PR TITLE
Feat: Show pointer on community sentiment badge on a snap page

### DIFF
--- a/src/features/snap/components/community-sentiment/CommunitySentiment.tsx
+++ b/src/features/snap/components/community-sentiment/CommunitySentiment.tsx
@@ -54,7 +54,11 @@ export const CommunitySentiment: FunctionComponent<CommunitySentimentProps> = ({
   const render = () => {
     return (
       <Box>
-        <Tag variant={getColorForSentiment(sentimentType)} onClick={onOpen}>
+        <Tag
+          variant={getColorForSentiment(sentimentType)}
+          onClick={onOpen}
+          cursor={'pointer'}
+        >
           <SignHexagonIcon margin={-1} fill="currentColor"></SignHexagonIcon>
           <TagLabel>
             <Trans>{sentimentType}</Trans>


### PR DESCRIPTION
## Description

Show pointer on community sentiment badge on a snap page

### Related ticket

Fixes #105 

### Type of change

- [ ] Chore
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
