### PR TITLE
chore: Use EntityName component inside MetadataAuditItem component

### DIFF
--- a/src/features/snap/components/Metadata.test.tsx
+++ b/src/features/snap/components/Metadata.test.tsx
@@ -6,8 +6,8 @@ jest.mock('../../../hooks');
 jest.mock('./community-sentiment', () => ({
   CommunitySentiment: () => <div data-testid="community-sentiment" />,
 }));
-jest.mock('./MetadataItems', () => ({
-  MetadataItems: () => <div data-testid="metadata-items" />,
+jest.mock('./MetadataItem', () => ({
+  MetadataItem: () => <div data-testid="metadata-item" />,
 }));
 jest.mock('./MetadataModal', () => ({
   MetadataModal: () => <div data-testid="metadata-modal" />,
@@ -41,7 +41,7 @@ describe('Metadata', () => {
 
     const { snap } = getMockSnap();
     const { queryByTestId } = render(<Metadata snap={snap} />);
-    expect(queryByTestId('metadata-items')).toBeInTheDocument();
+    expect(queryByTestId('metadata-item')).toBeInTheDocument();
   });
 
   it('renders the developer even when fetchSnapAssertionsForSnapId fails', () => {
@@ -69,7 +69,7 @@ describe('Metadata', () => {
       />,
     );
 
-    expect(queryByTestId('metadata-items')).toBeInTheDocument();
+    expect(queryByTestId('metadata-item')).toBeInTheDocument();
   });
 
   it('renders the key recovery link', () => {

--- a/src/features/snap/components/Metadata.tsx
+++ b/src/features/snap/components/Metadata.tsx
@@ -1,13 +1,13 @@
 import { Box, Flex, Link, useDisclosure } from '@chakra-ui/react';
 import { t, Trans } from '@lingui/macro';
-import { useEffect, type FunctionComponent } from 'react';
+import { type FunctionComponent, useEffect } from 'react';
 import type { Hex } from 'viem';
 
 import { Identifier, SourceCode } from '.';
 import { Category } from './Category';
 import { CommunitySentiment } from './community-sentiment';
 import { Data } from './Data';
-import { MetadataItems } from './MetadataItems';
+import { MetadataItem } from './MetadataItem';
 import { MetadataModal } from './MetadataModal';
 import { ExternalLink } from '../../../components';
 import type { RegistrySnapCategory } from '../../../constants';
@@ -78,7 +78,7 @@ export const Metadata: FunctionComponent<MetadataProps> = ({ snap }) => {
         )}
         <Data label={t`Identifier`} value={<Identifier snapId={snapId} />} />
         <CommunitySentiment snap={snap} />
-        {author && <MetadataItems address={author.address as Hex} />}
+        {author && <MetadataItem address={author.address as Hex} />}
         <Data
           label={t`Source Code`}
           value={

--- a/src/features/snap/components/MetadataAuditItem.test.tsx
+++ b/src/features/snap/components/MetadataAuditItem.test.tsx
@@ -1,4 +1,5 @@
 import { MetadataAuditItem } from './MetadataAuditItem';
+import { useVerifiableCredential } from '../../../hooks';
 import { VALID_ACCOUNT_1, render } from '../../../utils/test-utils';
 
 jest.mock('wagmi', () => ({
@@ -6,11 +7,29 @@ jest.mock('wagmi', () => ({
   useEnsName: jest.fn(),
 }));
 
+jest.mock('../../../hooks');
+
+jest.mock('../../../hooks/useVerifiableCredential', () => ({
+  ...jest.requireActual('../../../hooks/useVerifiableCredential'),
+  useVerifiableCredential: jest.fn(),
+}));
+
 jest.mock('../../../components/EntityName', () => ({
   EntityName: () => <div data-testid="entity-name" />,
 }));
 
 describe('MetadataAuditItem', () => {
+  let mockUseVerifiableCredential: jest.Mock;
+  beforeEach(() => {
+    mockUseVerifiableCredential = useVerifiableCredential as jest.Mock;
+    mockUseVerifiableCredential.mockClear();
+    mockUseVerifiableCredential.mockReturnValue({
+      accountVCBuilder: {
+        getSubjectDid: jest.fn().mockReturnValue(VALID_ACCOUNT_1),
+      },
+    });
+  });
+
   it('renders the auditor entity', async () => {
     const { queryByText, queryByTestId } = render(
       <MetadataAuditItem auditorAddresses={[VALID_ACCOUNT_1]} />,

--- a/src/features/snap/components/MetadataAuditItem.test.tsx
+++ b/src/features/snap/components/MetadataAuditItem.test.tsx
@@ -1,6 +1,3 @@
-import { act } from 'react-dom/test-utils';
-import { useEnsName } from 'wagmi';
-
 import { MetadataAuditItem } from './MetadataAuditItem';
 import { VALID_ACCOUNT_1, render } from '../../../utils/test-utils';
 
@@ -9,34 +6,17 @@ jest.mock('wagmi', () => ({
   useEnsName: jest.fn(),
 }));
 
-const buildEnsNameMock = (name?: string, isLoading = false) => {
-  const mockUseEnsName = useEnsName as jest.Mock;
-  mockUseEnsName.mockImplementation(() => ({
-    data: name,
-    isLoading,
-  }));
-};
+jest.mock('../../../components/EntityName', () => ({
+  EntityName: () => <div data-testid="entity-name" />,
+}));
 
 describe('MetadataAuditItem', () => {
-  it('renders the auditors', async () => {
-    buildEnsNameMock('ens.mock.name');
-    const { queryByText, getByText } = render(
+  it('renders the auditor entity', async () => {
+    const { queryByText, queryByTestId } = render(
       <MetadataAuditItem auditorAddresses={[VALID_ACCOUNT_1]} />,
     );
 
-    expect(queryByText('ens.mock.name')).toBeInTheDocument();
-
-    const link = getByText('ens.mock.name');
-
-    await act(async () => link.click());
-  });
-
-  it('renders the auditors without ens names', () => {
-    buildEnsNameMock(undefined);
-    const { queryByText } = render(
-      <MetadataAuditItem auditorAddresses={[VALID_ACCOUNT_1]} />,
-    );
-
-    expect(queryByText('ens.mock.name')).not.toBeInTheDocument();
+    expect(queryByText('Audited By')).toBeInTheDocument();
+    expect(queryByTestId('entity-name')).toBeInTheDocument();
   });
 });

--- a/src/features/snap/components/MetadataAuditItem.tsx
+++ b/src/features/snap/components/MetadataAuditItem.tsx
@@ -1,12 +1,9 @@
-import { Text } from '@chakra-ui/react';
 import { t } from '@lingui/macro';
-import { Link } from 'gatsby';
 import type { FunctionComponent } from 'react';
 import type { Hex } from 'viem';
-import { mainnet, useEnsName } from 'wagmi';
 
 import { Data } from './Data';
-import { trimAddress } from '../../../utils';
+import { EntityName } from '../../../components/EntityName';
 
 export type MetadataAuditItemProps = {
   auditorAddresses: Hex[];
@@ -15,27 +12,16 @@ export type MetadataAuditItemProps = {
 export const MetadataAuditItem: FunctionComponent<MetadataAuditItemProps> = ({
   auditorAddresses,
 }) => {
-  const auditors: any[] = [];
-  for (const address of auditorAddresses) {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const { data } = useEnsName({
-      address,
-      chainId: mainnet.id,
-    });
-    auditors.push(data ?? trimAddress(address));
-  }
   return (
     <>
-      {auditors.length > 0 && (
+      {auditorAddresses.length > 0 && (
         <Data
           label={t`Audited By`}
-          value={auditors.map((auditor, index) => (
-            <Link
+          value={auditorAddresses.map((auditorAddress, index) => (
+            <EntityName
               key={`auditor-${index}`}
-              to={`/account/?address=${auditorAddresses[index]}`}
-            >
-              <Text color="info.default">{auditor}</Text>
-            </Link>
+              subject={`did:pkh:eip155:1:${auditorAddress}`}
+            ></EntityName>
           ))}
         />
       )}

--- a/src/features/snap/components/MetadataAuditItem.tsx
+++ b/src/features/snap/components/MetadataAuditItem.tsx
@@ -4,6 +4,7 @@ import type { Hex } from 'viem';
 
 import { Data } from './Data';
 import { EntityName } from '../../../components/EntityName';
+import { useVerifiableCredential } from '../../../hooks';
 
 export type MetadataAuditItemProps = {
   auditorAddresses: Hex[];
@@ -12,6 +13,7 @@ export type MetadataAuditItemProps = {
 export const MetadataAuditItem: FunctionComponent<MetadataAuditItemProps> = ({
   auditorAddresses,
 }) => {
+  const { accountVCBuilder } = useVerifiableCredential();
   return (
     <>
       {auditorAddresses.length > 0 && (
@@ -20,7 +22,7 @@ export const MetadataAuditItem: FunctionComponent<MetadataAuditItemProps> = ({
           value={auditorAddresses.map((auditorAddress, index) => (
             <EntityName
               key={`auditor-${index}`}
-              subject={`did:pkh:eip155:1:${auditorAddress}`}
+              subject={accountVCBuilder.getSubjectDid(auditorAddress)}
             ></EntityName>
           ))}
         />

--- a/src/features/snap/components/MetadataAuditItem.tsx
+++ b/src/features/snap/components/MetadataAuditItem.tsx
@@ -21,9 +21,9 @@ export const MetadataAuditItem: FunctionComponent<MetadataAuditItemProps> = ({
           label={t`Audited By`}
           value={auditorAddresses.map((auditorAddress, index) => (
             <EntityName
-              key={`auditor-${index}`}
+              key={`${auditorAddress}-${index}`}
               subject={accountVCBuilder.getSubjectDid(auditorAddress)}
-            ></EntityName>
+            />
           ))}
         />
       )}

--- a/src/features/snap/components/MetadataItem.tsx
+++ b/src/features/snap/components/MetadataItem.tsx
@@ -6,11 +6,11 @@ import { Data } from './Data';
 import { EntityName } from '../../../components/EntityName';
 import { useVerifiableCredential } from '../../../hooks';
 
-export type MetadataItemsProps = {
+export type MetadataItemProps = {
   address: Hex;
 };
 
-export const MetadataItems: FunctionComponent<MetadataItemsProps> = ({
+export const MetadataItem: FunctionComponent<MetadataItemProps> = ({
   address,
 }) => {
   const { accountVCBuilder } = useVerifiableCredential();
@@ -20,9 +20,7 @@ export const MetadataItems: FunctionComponent<MetadataItemsProps> = ({
         <Data
           label={t`Developer`}
           value={
-            <EntityName
-              subject={accountVCBuilder.getSubjectDid(address)}
-            ></EntityName>
+            <EntityName subject={accountVCBuilder.getSubjectDid(address)} />
           }
         />
       )}

--- a/src/features/snap/components/MetadataItems.test.tsx
+++ b/src/features/snap/components/MetadataItems.test.tsx
@@ -1,6 +1,3 @@
-import { act } from 'react-dom/test-utils';
-import { useEnsName } from 'wagmi';
-
 import { MetadataItems } from './MetadataItems';
 import { VALID_ACCOUNT_1, render } from '../../../utils/test-utils';
 
@@ -9,32 +6,17 @@ jest.mock('wagmi', () => ({
   useEnsName: jest.fn(),
 }));
 
-const buildEnsNameMock = (name?: string, isLoading = false) => {
-  const mockUseEnsName = useEnsName as jest.Mock;
-  mockUseEnsName.mockImplementation(() => ({
-    data: name,
-    isLoading,
-  }));
-};
+jest.mock('../../../components/EntityName', () => ({
+  EntityName: () => <div data-testid="entity-name" />,
+}));
 
 describe('MetadataItems', () => {
-  it('renders the developer', async () => {
-    buildEnsNameMock('ens.mock.name');
-    const { queryByText, getByText } = render(
+  it('renders the developer entity', async () => {
+    const { queryByText, queryByTestId } = render(
       <MetadataItems address={VALID_ACCOUNT_1} />,
     );
 
-    expect(queryByText('ens.mock.name')).toBeInTheDocument();
-
-    const link = getByText('ens.mock.name');
-
-    await act(async () => link.click());
-  });
-
-  it('renders the developer without ens name', () => {
-    buildEnsNameMock(undefined);
-    const { queryByText } = render(<MetadataItems address={VALID_ACCOUNT_1} />);
-
-    expect(queryByText('ens.mock.name')).not.toBeInTheDocument();
+    expect(queryByText('Developer')).toBeInTheDocument();
+    expect(queryByTestId('entity-name')).toBeInTheDocument();
   });
 });

--- a/src/features/snap/components/MetadataItems.test.tsx
+++ b/src/features/snap/components/MetadataItems.test.tsx
@@ -1,9 +1,17 @@
 import { MetadataItems } from './MetadataItems';
+import { useVerifiableCredential } from '../../../hooks';
 import { VALID_ACCOUNT_1, render } from '../../../utils/test-utils';
+
+jest.mock('../../../hooks');
 
 jest.mock('wagmi', () => ({
   ...jest.requireActual('wagmi'),
   useEnsName: jest.fn(),
+}));
+
+jest.mock('../../../hooks/useVerifiableCredential', () => ({
+  ...jest.requireActual('../../../hooks/useVerifiableCredential'),
+  useVerifiableCredential: jest.fn(),
 }));
 
 jest.mock('../../../components/EntityName', () => ({
@@ -11,6 +19,17 @@ jest.mock('../../../components/EntityName', () => ({
 }));
 
 describe('MetadataItems', () => {
+  let mockUseVerifiableCredential: jest.Mock;
+  beforeEach(() => {
+    mockUseVerifiableCredential = useVerifiableCredential as jest.Mock;
+    mockUseVerifiableCredential.mockClear();
+    mockUseVerifiableCredential.mockReturnValue({
+      accountVCBuilder: {
+        getSubjectDid: jest.fn().mockReturnValue(VALID_ACCOUNT_1),
+      },
+    });
+  });
+
   it('renders the developer entity', async () => {
     const { queryByText, queryByTestId } = render(
       <MetadataItems address={VALID_ACCOUNT_1} />,

--- a/src/features/snap/components/MetadataItems.test.tsx
+++ b/src/features/snap/components/MetadataItems.test.tsx
@@ -1,6 +1,6 @@
-import { MetadataItems } from './MetadataItems';
+import { MetadataItem } from './MetadataItem';
 import { useVerifiableCredential } from '../../../hooks';
-import { VALID_ACCOUNT_1, render } from '../../../utils/test-utils';
+import { render, VALID_ACCOUNT_1 } from '../../../utils/test-utils';
 
 jest.mock('../../../hooks');
 
@@ -18,7 +18,7 @@ jest.mock('../../../components/EntityName', () => ({
   EntityName: () => <div data-testid="entity-name" />,
 }));
 
-describe('MetadataItems', () => {
+describe('MetadataItem', () => {
   let mockUseVerifiableCredential: jest.Mock;
   beforeEach(() => {
     mockUseVerifiableCredential = useVerifiableCredential as jest.Mock;
@@ -32,7 +32,7 @@ describe('MetadataItems', () => {
 
   it('renders the developer entity', async () => {
     const { queryByText, queryByTestId } = render(
-      <MetadataItems address={VALID_ACCOUNT_1} />,
+      <MetadataItem address={VALID_ACCOUNT_1} />,
     );
 
     expect(queryByText('Developer')).toBeInTheDocument();

--- a/src/features/snap/components/MetadataItems.tsx
+++ b/src/features/snap/components/MetadataItems.tsx
@@ -4,6 +4,7 @@ import type { Hex } from 'viem';
 
 import { Data } from './Data';
 import { EntityName } from '../../../components/EntityName';
+import { useVerifiableCredential } from '../../../hooks';
 
 export type MetadataItemsProps = {
   address: Hex;
@@ -12,13 +13,16 @@ export type MetadataItemsProps = {
 export const MetadataItems: FunctionComponent<MetadataItemsProps> = ({
   address,
 }) => {
+  const { accountVCBuilder } = useVerifiableCredential();
   return (
     <>
       {address && (
         <Data
           label={t`Developer`}
           value={
-            <EntityName subject={`did:pkh:eip155:1:${address}`}></EntityName>
+            <EntityName
+              subject={accountVCBuilder.getSubjectDid(address)}
+            ></EntityName>
           }
         />
       )}

--- a/src/features/snap/components/MetadataItems.tsx
+++ b/src/features/snap/components/MetadataItems.tsx
@@ -1,12 +1,9 @@
-import { Text } from '@chakra-ui/react';
 import { t } from '@lingui/macro';
-import { Link } from 'gatsby';
 import type { FunctionComponent } from 'react';
 import type { Hex } from 'viem';
-import { mainnet, useEnsName } from 'wagmi';
 
 import { Data } from './Data';
-import { trimAddress } from '../../../utils';
+import { EntityName } from '../../../components/EntityName';
 
 export type MetadataItemsProps = {
   address: Hex;
@@ -15,20 +12,13 @@ export type MetadataItemsProps = {
 export const MetadataItems: FunctionComponent<MetadataItemsProps> = ({
   address,
 }) => {
-  const { data } = useEnsName({
-    address,
-    chainId: mainnet.id,
-  });
-
   return (
     <>
       {address && (
         <Data
           label={t`Developer`}
           value={
-            <Link to={`/account/?address=${address}`}>
-              <Text color="info.default">{data ?? trimAddress(address)}</Text>
-            </Link>
+            <EntityName subject={`did:pkh:eip155:1:${address}`}></EntityName>
           }
         />
       )}

--- a/src/features/snap/components/MetadataModal.test.tsx
+++ b/src/features/snap/components/MetadataModal.test.tsx
@@ -10,8 +10,8 @@ jest.mock('.', () => ({
   MetadataAuditItem: () => <div data-testid="metadata-audit-item" />,
 }));
 
-jest.mock('./MetadataItems', () => ({
-  MetadataItems: () => <div data-testid="metadata-items" />,
+jest.mock('./MetadataItem', () => ({
+  MetadataItem: () => <div data-testid="metadata-item" />,
 }));
 
 jest.mock('./Audits', () => ({

--- a/src/features/snap/components/MetadataModal.tsx
+++ b/src/features/snap/components/MetadataModal.tsx
@@ -14,11 +14,11 @@ import { Identifier, MetadataAuditItem } from '.';
 import { Audits } from './Audits';
 import { Data } from './Data';
 import { Legal } from './Legal';
-import { MetadataItems } from './MetadataItems';
+import { MetadataItem } from './MetadataItem';
 import { SourceCode } from './SourceCode';
 import { ExternalLink } from '../../../components';
 import { useSelector } from '../../../hooks';
-import { getLinkText, type Fields } from '../../../utils';
+import { type Fields, getLinkText } from '../../../utils';
 import { getAuditorAddressesByNames } from '../../snaps';
 
 export type MetadataModalProps = {
@@ -76,7 +76,7 @@ export const MetadataModal: FunctionComponent<MetadataModalProps> = ({
         <ModalCloseButton />
         <ModalBody display="flex" flexDirection="column" gap="4">
           <Data label={t`Identifier`} value={<Identifier snapId={snapId} />} />
-          {author && <MetadataItems address={author.address as Hex} />}
+          {author && <MetadataItem address={author.address as Hex} />}
           <MetadataAuditItem auditorAddresses={auditorAddresses} />
           <Data label={t`Version`} value={latestVersion} />
           <Data

--- a/src/features/snap/components/index.ts
+++ b/src/features/snap/components/index.ts
@@ -6,7 +6,7 @@ export * from './DescriptionText';
 export * from './Identifier';
 export * from './Metadata';
 export * from './MetadataAuditItem';
-export * from './MetadataItems';
+export * from './MetadataItem';
 export * from './MetadataModal';
 export * from './Permissions';
 export * from './RelatedSnaps';

--- a/src/locales/de-DE/messages.po
+++ b/src/locales/de-DE/messages.po
@@ -395,7 +395,7 @@ msgstr ""
 
 #: src/components/icons/index.ts
 #: src/features/account/components/AccountRoleTags.tsx
-#: src/features/snap/components/MetadataItems.tsx
+#: src/features/snap/components/MetadataItem.tsx
 msgid "Developer"
 msgstr ""
 

--- a/src/locales/en-US/messages.po
+++ b/src/locales/en-US/messages.po
@@ -395,7 +395,7 @@ msgstr ""
 
 #: src/components/icons/index.ts
 #: src/features/account/components/AccountRoleTags.tsx
-#: src/features/snap/components/MetadataItems.tsx
+#: src/features/snap/components/MetadataItem.tsx
 msgid "Developer"
 msgstr ""
 

--- a/src/locales/ja-JP/messages.po
+++ b/src/locales/ja-JP/messages.po
@@ -395,7 +395,7 @@ msgstr ""
 
 #: src/components/icons/index.ts
 #: src/features/account/components/AccountRoleTags.tsx
-#: src/features/snap/components/MetadataItems.tsx
+#: src/features/snap/components/MetadataItem.tsx
 msgid "Developer"
 msgstr ""
 

--- a/src/locales/pt-BR/messages.po
+++ b/src/locales/pt-BR/messages.po
@@ -395,7 +395,7 @@ msgstr ""
 
 #: src/components/icons/index.ts
 #: src/features/account/components/AccountRoleTags.tsx
-#: src/features/snap/components/MetadataItems.tsx
+#: src/features/snap/components/MetadataItem.tsx
 msgid "Developer"
 msgstr ""
 

--- a/src/locales/ru-RU/messages.po
+++ b/src/locales/ru-RU/messages.po
@@ -395,7 +395,7 @@ msgstr ""
 
 #: src/components/icons/index.ts
 #: src/features/account/components/AccountRoleTags.tsx
-#: src/features/snap/components/MetadataItems.tsx
+#: src/features/snap/components/MetadataItem.tsx
 msgid "Developer"
 msgstr ""
 

--- a/src/locales/tr-TR/messages.po
+++ b/src/locales/tr-TR/messages.po
@@ -395,7 +395,7 @@ msgstr ""
 
 #: src/components/icons/index.ts
 #: src/features/account/components/AccountRoleTags.tsx
-#: src/features/snap/components/MetadataItems.tsx
+#: src/features/snap/components/MetadataItem.tsx
 msgid "Developer"
 msgstr ""
 

--- a/src/locales/zh-CN/messages.po
+++ b/src/locales/zh-CN/messages.po
@@ -395,7 +395,7 @@ msgstr ""
 
 #: src/components/icons/index.ts
 #: src/features/account/components/AccountRoleTags.tsx
-#: src/features/snap/components/MetadataItems.tsx
+#: src/features/snap/components/MetadataItem.tsx
 msgid "Developer"
 msgstr ""
 


### PR DESCRIPTION
## Description

Use common entity component on metadata page

### Related ticket

Fixes #166 

### Type of change

- [x] Chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
