### PR TITLE
feat: AAU I see the endorsements and reports on a snap

### DIFF
--- a/src/features/snap/assertions/store.test.ts
+++ b/src/features/snap/assertions/store.test.ts
@@ -10,6 +10,8 @@ import {
   getCurrentSnapStatusForIssuer,
   isSnapEndorsedByIssuer,
   isSnapReportedByIssuer,
+  SnapStatusReasonType,
+  getIssuedAssertionsForSnapId,
 } from './store';
 import {
   SnapCurrentStatus,
@@ -34,8 +36,13 @@ describe('snapAssertionsSlice', () => {
           {
             snapId: 'snap://snapId',
             issuer: 'issuer',
+            statusReason: {
+              type: SnapStatusReasonType.Endorse,
+              value: ['Reason'],
+            },
             currentStatus: SnapCurrentStatus.Endorsed,
             creationAt: new Date(),
+            issuanceDate: new Date(),
           },
         ],
       };
@@ -69,8 +76,13 @@ describe('Selectors', () => {
       const snapAssertion = {
         snapId: 'snap://snapId',
         issuer: 'issuer',
+        statusReason: {
+          type: SnapStatusReasonType.Endorse,
+          value: ['Reason'],
+        },
         currentStatus: SnapCurrentStatus.Endorsed,
         creationAt: new Date(),
+        issuanceDate: new Date(),
       };
       const mockedApplicationState: ApplicationState = mock<ApplicationState>();
       mockedApplicationState.snapAssertions.snapAssertions = [snapAssertion];
@@ -84,6 +96,67 @@ describe('Selectors', () => {
         endorsementsCount: 1,
         reportsCount: 0,
       });
+    });
+  });
+
+  describe('getIssuedAssertionsForSnapId', () => {
+    it('should return blank array if no assertions found', () => {
+      const mockedApplicationState: ApplicationState = mock<ApplicationState>();
+      mockedApplicationState.snapAssertions.snapAssertions = [];
+      const result = getIssuedAssertionsForSnapId('snapId')(
+        mockedApplicationState,
+      );
+      expect(result).toStrictEqual([]);
+    });
+
+    it('should return the assertions for a Snap', () => {
+      const earlierDate = new Date('2022-01-01');
+      const middleDate = new Date('2022-01-02');
+      const laterDate = new Date('2022-01-03');
+      const snapAssertion1: SnapAssertionState = {
+        snapId: 'snap://snapId1',
+        issuer: 'issuer',
+        statusReason: {
+          type: SnapStatusReasonType.Endorse,
+          value: ['Reason'],
+        },
+        currentStatus: SnapCurrentStatus.Endorsed,
+        creationAt: earlierDate, // Earlier date
+        issuanceDate: earlierDate,
+      };
+      const snapAssertion2: SnapAssertionState = {
+        snapId: 'snap://snapId1',
+        issuer: 'issuer',
+        statusReason: {
+          type: SnapStatusReasonType.Malicious,
+          value: ['Reason'],
+        },
+        currentStatus: SnapCurrentStatus.Disputed,
+        creationAt: laterDate, // Later date
+        issuanceDate: laterDate,
+      };
+      const snapAssertion3: SnapAssertionState = {
+        snapId: 'snap://snapId2',
+        issuer: 'issuer',
+        statusReason: {
+          type: SnapStatusReasonType.Endorse,
+          value: ['Reason'],
+        },
+        currentStatus: SnapCurrentStatus.Endorsed,
+        creationAt: middleDate, // Middle date
+        issuanceDate: middleDate,
+      };
+      const mockedApplicationState: ApplicationState = mock<ApplicationState>();
+      mockedApplicationState.snapAssertions.snapAssertions = [
+        snapAssertion1,
+        snapAssertion2,
+        snapAssertion3,
+      ];
+
+      const result = getIssuedAssertionsForSnapId('snapId1')(
+        mockedApplicationState,
+      );
+      expect(result).toStrictEqual([snapAssertion2, snapAssertion1]);
     });
   });
 
@@ -105,20 +178,35 @@ describe('Selectors', () => {
       const snapAssertion1: SnapAssertionState = {
         snapId: 'snap://snapId',
         issuer: 'issuer',
+        statusReason: {
+          type: SnapStatusReasonType.Endorse,
+          value: ['Reason'],
+        },
         currentStatus: SnapCurrentStatus.Endorsed,
         creationAt: earlierDate, // Earlier date
+        issuanceDate: earlierDate,
       };
       const snapAssertion2: SnapAssertionState = {
         snapId: 'snap://snapId',
         issuer: 'issuer',
+        statusReason: {
+          type: SnapStatusReasonType.Malicious,
+          value: ['Reason'],
+        },
         currentStatus: SnapCurrentStatus.Disputed,
         creationAt: laterDate, // Later date
+        issuanceDate: laterDate,
       };
       const snapAssertion3: SnapAssertionState = {
         snapId: 'snap://snapId',
         issuer: 'issuer',
+        statusReason: {
+          type: SnapStatusReasonType.Endorse,
+          value: ['Reason'],
+        },
         currentStatus: SnapCurrentStatus.Endorsed,
         creationAt: middleDate, // Middle date
+        issuanceDate: middleDate,
       };
       const mockedApplicationState: ApplicationState = mock<ApplicationState>();
       mockedApplicationState.snapAssertions.snapAssertions = [
@@ -150,8 +238,13 @@ describe('Selectors', () => {
       const snapAssertion: SnapAssertionState = {
         snapId: 'snap://snapId',
         issuer: 'issuer',
+        statusReason: {
+          type: SnapStatusReasonType.Endorse,
+          value: ['Reason'],
+        },
         currentStatus: SnapCurrentStatus.Endorsed,
         creationAt: new Date(),
+        issuanceDate: new Date(),
       };
       const mockedApplicationState: ApplicationState = mock<ApplicationState>();
       mockedApplicationState.snapAssertions.snapAssertions = [snapAssertion];
@@ -167,8 +260,13 @@ describe('Selectors', () => {
       const snapAssertion: SnapAssertionState = {
         snapId: 'snap://snapId',
         issuer: 'issuer',
+        statusReason: {
+          type: SnapStatusReasonType.Malicious,
+          value: ['Reason'],
+        },
         currentStatus: SnapCurrentStatus.Disputed,
         creationAt: new Date(),
+        issuanceDate: new Date(),
       };
       const mockedApplicationState: ApplicationState = mock<ApplicationState>();
       mockedApplicationState.snapAssertions.snapAssertions = [snapAssertion];
@@ -196,8 +294,13 @@ describe('Selectors', () => {
       const snapAssertion: SnapAssertionState = {
         snapId: 'snap://snapId',
         issuer: 'issuer',
+        statusReason: {
+          type: SnapStatusReasonType.Malicious,
+          value: ['Reason'],
+        },
         currentStatus: SnapCurrentStatus.Disputed,
         creationAt: new Date(),
+        issuanceDate: new Date(),
       };
       const mockedApplicationState: ApplicationState = mock<ApplicationState>();
       mockedApplicationState.snapAssertions.snapAssertions = [snapAssertion];
@@ -213,8 +316,13 @@ describe('Selectors', () => {
       const snapAssertion: SnapAssertionState = {
         snapId: 'snap://snapId',
         issuer: 'issuer',
+        statusReason: {
+          type: SnapStatusReasonType.Endorse,
+          value: ['Reason'],
+        },
         currentStatus: SnapCurrentStatus.Endorsed,
         creationAt: new Date(),
+        issuanceDate: new Date(),
       };
       const mockedApplicationState: ApplicationState = mock<ApplicationState>();
       mockedApplicationState.snapAssertions.snapAssertions = [snapAssertion];

--- a/src/features/snap/assertions/store.ts
+++ b/src/features/snap/assertions/store.ts
@@ -4,11 +4,18 @@ import { fetchSnapAssertionsForSnapId } from './api';
 import { SnapCurrentStatus } from './types';
 import { type ApplicationState } from '../../../store';
 
+export enum SnapStatusReasonType {
+  Endorse = 'Endorse',
+  Malicious = 'Malicious',
+}
+
 export type SnapAssertionState = {
   snapId: string;
   issuer: string;
   currentStatus: SnapCurrentStatus;
+  statusReason: { type: SnapStatusReasonType; value?: string[] | undefined };
   creationAt: Date;
+  issuanceDate: Date;
 };
 
 export type SnapAssertionsState = {
@@ -49,7 +56,9 @@ export const snapAssertionsSlice = createSlice({
             snapId: assertion.assertion.credentialSubject.id,
             issuer: assertion.assertion.issuer,
             currentStatus: assertion.assertion.credentialSubject.currentStatus,
+            statusReason: assertion.assertion.credentialSubject.statusReason,
             creationAt: assertion.creationAt,
+            issuanceDate: assertion.assertion.issuanceDate,
           };
         });
       state.snapAssertions = [
@@ -82,6 +91,24 @@ export const getSnapAssertionDetailsForSnapId = (snapId: string) =>
           assertion.currentStatus === SnapCurrentStatus.Disputed,
       ).length,
     };
+  });
+
+// Selector to get assertions for a specific snapId
+export const getIssuedAssertionsForSnapId = (snapId: string) =>
+  createSelector(getSnapAssertions, (snapAssertions) => {
+    const filteredAssertions = snapAssertions.filter(
+      (assertion) => assertion.snapId === `snap://${snapId}`,
+    );
+
+    // Sort the filtered assertions array by `issuanceDate` in descending order
+    filteredAssertions.sort((a, b) => {
+      return (
+        new Date(b.issuanceDate).getTime() - new Date(a.issuanceDate).getTime()
+      );
+    });
+
+    // Return only the top 100 records
+    return filteredAssertions.slice(0, 100);
   });
 
 export const getCurrentSnapStatusForIssuer = (snapId: string, issuer: string) =>

--- a/src/features/snap/assertions/types.ts
+++ b/src/features/snap/assertions/types.ts
@@ -60,4 +60,5 @@ export type SnapAssertionResponse = {
   type: string;
   proof?: ProofEip712;
   credentialSubject: SnapCredentialSubject;
+  issuanceDate: Date;
 };

--- a/src/features/snap/components/activity/ActivityItem.test.tsx
+++ b/src/features/snap/components/activity/ActivityItem.test.tsx
@@ -1,0 +1,83 @@
+import { act } from '@testing-library/react';
+
+import { ActivityItem } from './ActivityItem';
+import { render } from '../../../../utils/test-utils';
+import type { SnapAssertionState } from '../../assertions/store';
+import {
+  SnapCurrentStatus,
+  SnapStatusReasonType,
+} from '../../assertions/types';
+
+jest.mock('../../../../hooks', () => ({
+  ...jest.requireActual('../../../../hooks'),
+  useSelector: jest.fn(),
+  useVerifiableCredential: jest.fn(),
+}));
+
+jest.mock('../../../../components/EntityName', () => ({
+  EntityName: () => <div data-testid="entity-name" />,
+}));
+
+const snapEndorsementAssertion: SnapAssertionState = {
+  snapId: 'snap://mockChecksum',
+  issuer: '0xmockAddress1',
+  statusReason: { type: SnapStatusReasonType.Endorse, value: ['Reason'] },
+  creationAt: new Date(),
+  issuanceDate: new Date(),
+  currentStatus: SnapCurrentStatus.Endorsed,
+};
+
+const snapReportAssertion: SnapAssertionState = {
+  snapId: 'snap://mockChecksum',
+  issuer: '0xmockAddress2',
+  statusReason: { type: SnapStatusReasonType.Malicious, value: ['Reason'] },
+  creationAt: new Date(),
+  issuanceDate: new Date(),
+  currentStatus: SnapCurrentStatus.Disputed,
+};
+
+describe('ActivityItem', () => {
+  it('renders a snap endorsement activity item', async () => {
+    const { queryByTestId, queryByText } = await act(async () =>
+      render(<ActivityItem assertion={snapEndorsementAssertion} />),
+    );
+
+    expect(queryByTestId('entity-name')).toBeInTheDocument();
+    expect(queryByText('Endorsed by')).toBeInTheDocument();
+  });
+
+  it('renders a snap report activity item', async () => {
+    const { queryByTestId, queryByText } = await act(async () =>
+      render(<ActivityItem assertion={snapReportAssertion} />),
+    );
+
+    expect(queryByTestId('entity-name')).toBeInTheDocument();
+    expect(queryByText('Reported by')).toBeInTheDocument();
+  });
+
+  it('renders an activity item even with multiple reasons', async () => {
+    snapEndorsementAssertion.statusReason.value = [
+      'Reason1',
+      'Reason2',
+      'Reason3',
+    ];
+
+    const { queryByText, queryByTestId } = await act(async () =>
+      render(<ActivityItem assertion={snapEndorsementAssertion} />),
+    );
+
+    expect(queryByText('for Reason1, Reason2 and Reason3')).toBeInTheDocument();
+    expect(queryByTestId('entity-name')).toBeInTheDocument();
+  });
+
+  it('renders an activity item even without any reasons', async () => {
+    snapEndorsementAssertion.statusReason.value = undefined;
+
+    const { queryByText, queryByTestId } = await act(async () =>
+      render(<ActivityItem assertion={snapEndorsementAssertion} />),
+    );
+
+    expect(queryByText('for')).not.toBeInTheDocument();
+    expect(queryByTestId('entity-name')).toBeInTheDocument();
+  });
+});

--- a/src/features/snap/components/activity/ActivityItem.tsx
+++ b/src/features/snap/components/activity/ActivityItem.tsx
@@ -1,0 +1,65 @@
+import { Box, HStack, Text } from '@chakra-ui/react';
+import { t } from '@lingui/macro';
+import { formatDistanceToNow } from 'date-fns';
+import type { FunctionComponent } from 'react';
+import { useCallback } from 'react';
+
+import { StarFilledIcon, WarningIcon } from '../../../../components';
+import { EntityName } from '../../../../components/EntityName';
+import type { SnapAssertionState } from '../../assertions/store';
+import { SnapCurrentStatus } from '../../assertions/types';
+
+export type ActivityItemProps = {
+  assertion: SnapAssertionState;
+};
+
+export const ActivityItem: FunctionComponent<ActivityItemProps> = ({
+  assertion,
+}) => {
+  const type = useCallback(() => {
+    if (assertion.currentStatus === SnapCurrentStatus.Endorsed) {
+      return (
+        <span style={{ display: 'flex', alignItems: 'center' }}>
+          <StarFilledIcon width="20px" fill="icon.muted" mr={2} />
+          {t`Endorsed by`}
+        </span>
+      );
+    }
+    return (
+      <span style={{ display: 'flex', alignItems: 'center' }}>
+        <WarningIcon width="20px" fill="icon.muted" mr={2} />
+        {t`Reported by`}
+      </span>
+    );
+  }, [assertion]);
+
+  const reason = useCallback(() => {
+    const reasons = [...(assertion.statusReason?.value ?? [])];
+
+    if (!reasons || reasons.length === 0) {
+      return '';
+    } else if (reasons.length === 1) {
+      return `for ${reasons[0]}`;
+    }
+
+    const lastItem = reasons.pop();
+    const lastItemLink = t`and`;
+
+    return `for ${reasons.join(', ')} ${lastItemLink} ${lastItem}`;
+  }, [assertion]);
+
+  return (
+    <HStack mb={4} width={'100%'} justifyContent={'space-between'}>
+      <HStack>
+        <Text>{type()}</Text>
+        <EntityName subject={assertion.issuer} />
+        <Text>{reason()}</Text>
+      </HStack>
+      <Box alignContent={'flex-end'}>
+        <Text color={'icon.muted'}>
+          {formatDistanceToNow(assertion.issuanceDate, { addSuffix: true })}
+        </Text>
+      </Box>
+    </HStack>
+  );
+};

--- a/src/features/snap/components/activity/ActivitySection.test.tsx
+++ b/src/features/snap/components/activity/ActivitySection.test.tsx
@@ -1,0 +1,50 @@
+import { act } from '@testing-library/react';
+import { mock } from 'ts-mockito';
+
+import { ActivitySection } from './ActivitySection';
+import { useSelector } from '../../../../hooks';
+import { createStore } from '../../../../store';
+import { render } from '../../../../utils/test-utils';
+import type { SnapAssertionState } from '../../assertions/store';
+
+jest.mock('../../../../hooks', () => ({
+  ...jest.requireActual('../../../../hooks'),
+  useSelector: jest.fn(),
+}));
+
+jest.mock('./ActivityItem', () => ({
+  ActivityItem: () => <div data-testid="activity-item" />,
+}));
+
+describe('ActivitySection', () => {
+  let mockUseSelector: jest.Mock;
+
+  beforeEach(() => {
+    mockUseSelector = useSelector as jest.Mock;
+  });
+
+  it('renders multiple activities', async () => {
+    mockUseSelector.mockReturnValueOnce([
+      mock<SnapAssertionState>,
+      mock<SnapAssertionState>,
+    ]);
+
+    const store = createStore();
+
+    const { queryAllByTestId } = await act(async () =>
+      render(<ActivitySection latestChecksum={'snap1checksum'} />, store),
+    );
+
+    expect(queryAllByTestId('activity-item')).toHaveLength(2);
+  });
+
+  it('hides when no activity', async () => {
+    const store = createStore();
+
+    const { queryByTestId } = await act(async () =>
+      render(<ActivitySection latestChecksum={'snap1checksum'} />, store),
+    );
+
+    expect(queryByTestId('activity-item')).not.toBeInTheDocument();
+  });
+});

--- a/src/features/snap/components/activity/ActivitySection.tsx
+++ b/src/features/snap/components/activity/ActivitySection.tsx
@@ -1,0 +1,38 @@
+import { Box, Divider, Heading } from '@chakra-ui/react';
+import { t } from '@lingui/macro';
+import type { FunctionComponent } from 'react';
+
+import { ActivityItem } from './ActivityItem';
+import { useSelector } from '../../../../hooks';
+import { getIssuedAssertionsForSnapId } from '../../assertions/store';
+
+export type ActivitySectionProps = {
+  latestChecksum: string;
+};
+
+export const ActivitySection: FunctionComponent<ActivitySectionProps> = ({
+  latestChecksum,
+}) => {
+  const assertions = useSelector(getIssuedAssertionsForSnapId(latestChecksum));
+
+  if (assertions && assertions.length !== 0) {
+    return (
+      <>
+        <Divider mt="3rem" mb="2rem" />
+        <Heading as="h2" fontSize="2xl" mb="2rem">
+          {t`Activity`}
+        </Heading>
+        <Box data-testid="activity-section">
+          {assertions.map((assertion, index) => (
+            <ActivityItem
+              key={`${assertion.snapId}-${index}`}
+              assertion={assertion}
+            />
+          ))}
+        </Box>
+      </>
+    );
+  }
+
+  return null;
+};

--- a/src/locales/de-DE/messages.po
+++ b/src/locales/de-DE/messages.po
@@ -118,6 +118,7 @@ msgid "Account Profile"
 msgstr ""
 
 #: src/features/account/components/activity/ActivitySection.tsx
+#: src/features/snap/components/activity/ActivitySection.tsx
 msgid "Activity"
 msgstr ""
 
@@ -260,6 +261,7 @@ msgid "Alphabetical"
 msgstr ""
 
 #: src/features/account/components/activity/ActivityItem.tsx
+#: src/features/snap/components/activity/ActivityItem.tsx
 msgid "and"
 msgstr ""
 
@@ -483,6 +485,7 @@ msgid "Endorsed"
 msgstr ""
 
 #: src/features/account/components/technical-expertise/TechnicalExpertiseItem.tsx
+#: src/features/snap/components/activity/ActivityItem.tsx
 msgid "Endorsed by"
 msgstr ""
 
@@ -928,6 +931,10 @@ msgstr ""
 #: src/features/account/components/activity/ActivityItem.tsx
 #: src/features/account/components/activity/ActivityItem.tsx
 msgid "Reported"
+msgstr ""
+
+#: src/features/snap/components/activity/ActivityItem.tsx
+msgid "Reported by"
 msgstr ""
 
 #: src/pages/explore.tsx

--- a/src/locales/en-US/messages.po
+++ b/src/locales/en-US/messages.po
@@ -118,6 +118,7 @@ msgid "Account Profile"
 msgstr ""
 
 #: src/features/account/components/activity/ActivitySection.tsx
+#: src/features/snap/components/activity/ActivitySection.tsx
 msgid "Activity"
 msgstr ""
 
@@ -260,6 +261,7 @@ msgid "Alphabetical"
 msgstr ""
 
 #: src/features/account/components/activity/ActivityItem.tsx
+#: src/features/snap/components/activity/ActivityItem.tsx
 msgid "and"
 msgstr ""
 
@@ -483,6 +485,7 @@ msgid "Endorsed"
 msgstr ""
 
 #: src/features/account/components/technical-expertise/TechnicalExpertiseItem.tsx
+#: src/features/snap/components/activity/ActivityItem.tsx
 msgid "Endorsed by"
 msgstr ""
 
@@ -928,6 +931,10 @@ msgstr ""
 #: src/features/account/components/activity/ActivityItem.tsx
 #: src/features/account/components/activity/ActivityItem.tsx
 msgid "Reported"
+msgstr ""
+
+#: src/features/snap/components/activity/ActivityItem.tsx
+msgid "Reported by"
 msgstr ""
 
 #: src/pages/explore.tsx

--- a/src/locales/ja-JP/messages.po
+++ b/src/locales/ja-JP/messages.po
@@ -118,6 +118,7 @@ msgid "Account Profile"
 msgstr ""
 
 #: src/features/account/components/activity/ActivitySection.tsx
+#: src/features/snap/components/activity/ActivitySection.tsx
 msgid "Activity"
 msgstr ""
 
@@ -260,6 +261,7 @@ msgid "Alphabetical"
 msgstr ""
 
 #: src/features/account/components/activity/ActivityItem.tsx
+#: src/features/snap/components/activity/ActivityItem.tsx
 msgid "and"
 msgstr ""
 
@@ -483,6 +485,7 @@ msgid "Endorsed"
 msgstr ""
 
 #: src/features/account/components/technical-expertise/TechnicalExpertiseItem.tsx
+#: src/features/snap/components/activity/ActivityItem.tsx
 msgid "Endorsed by"
 msgstr ""
 
@@ -928,6 +931,10 @@ msgstr ""
 #: src/features/account/components/activity/ActivityItem.tsx
 #: src/features/account/components/activity/ActivityItem.tsx
 msgid "Reported"
+msgstr ""
+
+#: src/features/snap/components/activity/ActivityItem.tsx
+msgid "Reported by"
 msgstr ""
 
 #: src/pages/explore.tsx

--- a/src/locales/pt-BR/messages.po
+++ b/src/locales/pt-BR/messages.po
@@ -118,6 +118,7 @@ msgid "Account Profile"
 msgstr ""
 
 #: src/features/account/components/activity/ActivitySection.tsx
+#: src/features/snap/components/activity/ActivitySection.tsx
 msgid "Activity"
 msgstr ""
 
@@ -260,6 +261,7 @@ msgid "Alphabetical"
 msgstr ""
 
 #: src/features/account/components/activity/ActivityItem.tsx
+#: src/features/snap/components/activity/ActivityItem.tsx
 msgid "and"
 msgstr ""
 
@@ -483,6 +485,7 @@ msgid "Endorsed"
 msgstr ""
 
 #: src/features/account/components/technical-expertise/TechnicalExpertiseItem.tsx
+#: src/features/snap/components/activity/ActivityItem.tsx
 msgid "Endorsed by"
 msgstr ""
 
@@ -928,6 +931,10 @@ msgstr ""
 #: src/features/account/components/activity/ActivityItem.tsx
 #: src/features/account/components/activity/ActivityItem.tsx
 msgid "Reported"
+msgstr ""
+
+#: src/features/snap/components/activity/ActivityItem.tsx
+msgid "Reported by"
 msgstr ""
 
 #: src/pages/explore.tsx

--- a/src/locales/ru-RU/messages.po
+++ b/src/locales/ru-RU/messages.po
@@ -118,6 +118,7 @@ msgid "Account Profile"
 msgstr ""
 
 #: src/features/account/components/activity/ActivitySection.tsx
+#: src/features/snap/components/activity/ActivitySection.tsx
 msgid "Activity"
 msgstr ""
 
@@ -260,6 +261,7 @@ msgid "Alphabetical"
 msgstr ""
 
 #: src/features/account/components/activity/ActivityItem.tsx
+#: src/features/snap/components/activity/ActivityItem.tsx
 msgid "and"
 msgstr ""
 
@@ -483,6 +485,7 @@ msgid "Endorsed"
 msgstr ""
 
 #: src/features/account/components/technical-expertise/TechnicalExpertiseItem.tsx
+#: src/features/snap/components/activity/ActivityItem.tsx
 msgid "Endorsed by"
 msgstr ""
 
@@ -928,6 +931,10 @@ msgstr ""
 #: src/features/account/components/activity/ActivityItem.tsx
 #: src/features/account/components/activity/ActivityItem.tsx
 msgid "Reported"
+msgstr ""
+
+#: src/features/snap/components/activity/ActivityItem.tsx
+msgid "Reported by"
 msgstr ""
 
 #: src/pages/explore.tsx

--- a/src/locales/tr-TR/messages.po
+++ b/src/locales/tr-TR/messages.po
@@ -118,6 +118,7 @@ msgid "Account Profile"
 msgstr ""
 
 #: src/features/account/components/activity/ActivitySection.tsx
+#: src/features/snap/components/activity/ActivitySection.tsx
 msgid "Activity"
 msgstr ""
 
@@ -260,6 +261,7 @@ msgid "Alphabetical"
 msgstr ""
 
 #: src/features/account/components/activity/ActivityItem.tsx
+#: src/features/snap/components/activity/ActivityItem.tsx
 msgid "and"
 msgstr ""
 
@@ -483,6 +485,7 @@ msgid "Endorsed"
 msgstr ""
 
 #: src/features/account/components/technical-expertise/TechnicalExpertiseItem.tsx
+#: src/features/snap/components/activity/ActivityItem.tsx
 msgid "Endorsed by"
 msgstr ""
 
@@ -928,6 +931,10 @@ msgstr ""
 #: src/features/account/components/activity/ActivityItem.tsx
 #: src/features/account/components/activity/ActivityItem.tsx
 msgid "Reported"
+msgstr ""
+
+#: src/features/snap/components/activity/ActivityItem.tsx
+msgid "Reported by"
 msgstr ""
 
 #: src/pages/explore.tsx

--- a/src/locales/zh-CN/messages.po
+++ b/src/locales/zh-CN/messages.po
@@ -118,6 +118,7 @@ msgid "Account Profile"
 msgstr ""
 
 #: src/features/account/components/activity/ActivitySection.tsx
+#: src/features/snap/components/activity/ActivitySection.tsx
 msgid "Activity"
 msgstr ""
 
@@ -260,6 +261,7 @@ msgid "Alphabetical"
 msgstr ""
 
 #: src/features/account/components/activity/ActivityItem.tsx
+#: src/features/snap/components/activity/ActivityItem.tsx
 msgid "and"
 msgstr ""
 
@@ -483,6 +485,7 @@ msgid "Endorsed"
 msgstr ""
 
 #: src/features/account/components/technical-expertise/TechnicalExpertiseItem.tsx
+#: src/features/snap/components/activity/ActivityItem.tsx
 msgid "Endorsed by"
 msgstr ""
 
@@ -928,6 +931,10 @@ msgstr ""
 #: src/features/account/components/activity/ActivityItem.tsx
 #: src/features/account/components/activity/ActivityItem.tsx
 msgid "Reported"
+msgstr ""
+
+#: src/features/snap/components/activity/ActivityItem.tsx
+msgid "Reported by"
 msgstr ""
 
 #: src/pages/explore.tsx

--- a/src/pages/snap/{Snap.location}/{Snap.slug}.tsx
+++ b/src/pages/snap/{Snap.location}/{Snap.slug}.tsx
@@ -21,6 +21,7 @@ import {
   RelatedSnaps,
   useGetInstalledSnapsQuery,
 } from '../../../features';
+import { ActivitySection } from '../../../features/snap/components/activity/ActivitySection';
 import { EndorseSnap } from '../../../features/snap/components/EndorseSnap';
 import { ReportSnap } from '../../../features/snap/components/ReportSnap';
 import type { Fields } from '../../../utils';
@@ -138,6 +139,8 @@ const SnapPage: FunctionComponent<SnapPageProps> = ({ data }) => {
           <Description name={name} description={description} />
           <Permissions snap={data.snap} permissions={permissions} />
         </Stack>
+
+        <ActivitySection latestChecksum={latestChecksum} />
 
         {/* TODO: Enable account management category when there are more Snaps
             in the registry. */}


### PR DESCRIPTION
## Description

AAU I see the endorsements and reports on a snap

<img width="1296" alt="image" src="https://github.com/MetaMask/permissionless-snaps-directory/assets/77279246/ba2d404e-fbfe-45ce-9b60-3fa7de19407c">

### Related ticket

Fixes #113 

### Type of change

- [ ] Chore
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
