### PR TITLE
fix: DID is displayed instead of ENS/address in "Developer" for a Snap

### DIFF
--- a/src/components/EntityName.test.tsx
+++ b/src/components/EntityName.test.tsx
@@ -100,4 +100,15 @@ describe('ActivitySubject', () => {
 
     expect(queryByText('cool title')).toBeInTheDocument();
   });
+
+  it('renders an item without surrounding margin', async () => {
+    const { queryByText } = await act(async () =>
+      render(
+        <EntityName subject={peerSubject} isSnap={false} noMargin={true} />,
+      ),
+    );
+
+    const item = queryByText('test.eth');
+    expect(item).toBeInTheDocument();
+  });
 });

--- a/src/components/EntityName.tsx
+++ b/src/components/EntityName.tsx
@@ -15,12 +15,14 @@ export type ActivitySubjectProps = {
   subject: string;
   isSnap: boolean;
   title?: string;
+  noMargin?: boolean;
 };
 
 export const EntityName: FunctionComponent<ActivitySubjectProps> = ({
   subject,
   isSnap,
   title,
+  noMargin,
 }) => {
   const snap = useSelector(getSnapByChecksum(subject));
 
@@ -48,7 +50,7 @@ export const EntityName: FunctionComponent<ActivitySubjectProps> = ({
 
   return (
     <Link to={buildLink()}>
-      <Text color="info.default" ml={-1} mr={-1}>
+      <Text color="info.default" mx={noMargin ? 0 : -1}>
         {displaySubject()}
       </Text>
     </Link>

--- a/src/features/snap/components/Metadata.tsx
+++ b/src/features/snap/components/Metadata.tsx
@@ -78,7 +78,7 @@ export const Metadata: FunctionComponent<MetadataProps> = ({ snap }) => {
         )}
         <Data label={t`Identifier`} value={<Identifier snapId={snapId} />} />
         <CommunitySentiment snap={snap} />
-        {author && <MetadataItem address={author.address as Hex} />}
+        {author?.address && <MetadataItem address={author.address as Hex} />}
         <Data
           label={t`Source Code`}
           value={

--- a/src/features/snap/components/MetadataItem.tsx
+++ b/src/features/snap/components/MetadataItem.tsx
@@ -1,29 +1,21 @@
 import { t } from '@lingui/macro';
 import type { FunctionComponent } from 'react';
-import type { Hex } from 'viem';
+import type { Address } from 'viem';
 
 import { Data } from './Data';
 import { EntityName } from '../../../components/EntityName';
-import { useVerifiableCredential } from '../../../hooks';
 
 export type MetadataItemProps = {
-  address: Hex;
+  address: Address;
 };
 
 export const MetadataItem: FunctionComponent<MetadataItemProps> = ({
   address,
 }) => {
-  const { accountVCBuilder } = useVerifiableCredential();
   return (
-    <>
-      {address && (
-        <Data
-          label={t`Developer`}
-          value={
-            <EntityName subject={accountVCBuilder.getSubjectDid(address)} />
-          }
-        />
-      )}
-    </>
+    <Data
+      label={t`Developer`}
+      value={<EntityName subject={address} isSnap={false} noMargin={true} />}
+    />
   );
 };

--- a/src/features/snap/components/MetadataModal.tsx
+++ b/src/features/snap/components/MetadataModal.tsx
@@ -76,7 +76,7 @@ export const MetadataModal: FunctionComponent<MetadataModalProps> = ({
         <ModalCloseButton />
         <ModalBody display="flex" flexDirection="column" gap="4">
           <Data label={t`Identifier`} value={<Identifier snapId={snapId} />} />
-          {author && <MetadataItem address={author.address as Hex} />}
+          {author?.address && <MetadataItem address={author.address as Hex} />}
           <MetadataAuditItem auditorAddresses={auditorAddresses} />
           <Data label={t`Version`} value={latestVersion} />
           <Data


### PR DESCRIPTION
## Description

- Fixes an issue where the DID would be displayed instead of the ENS/address for the developer of a Snap
- Aligns the developer ENS/address below the label

### Related ticket

Fixes #181 

### Type of change

- [ ] Chore
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
