### PR TITLE
Fix: Change filtering logic on community page

### DIFF
--- a/src/features/users/api.ts
+++ b/src/features/users/api.ts
@@ -44,8 +44,9 @@ export const fetchUsers = createAsyncThunk(
       filterTypes.push(FilterType.ReportedUsers);
     }
     try {
-      const filtersQuery =
-        filterTypes.length > 0 ? `?filters=${JSON.stringify(filterTypes)}` : '';
+      const filtersQuery = `?filters=${
+        filterTypes.length > 0 ? JSON.stringify(filterTypes) : '[]'
+      }`;
       const userIdQuery = filterArgs.userId
         ? `&userId=${filterArgs.userId}`
         : '';

--- a/src/features/users/store.test.ts
+++ b/src/features/users/store.test.ts
@@ -41,27 +41,33 @@ const initialState: {
 
 describe('filterUsersSlice', () => {
   it('should toggle endorsedByYou', () => {
-    const nextState = filterUsersSlice.reducer(
+    let nextState = filterUsersSlice.reducer(
       initialState,
       toggleEndorsedByYou(),
     );
     expect(nextState.endorsedByYou).toBe(true);
+    nextState = filterUsersSlice.reducer(nextState, toggleEndorsedByYou());
+    expect(nextState.endorsedByYou).toBe(false);
   });
 
   it('should toggle reportedByYou', () => {
-    const nextState = filterUsersSlice.reducer(
+    let nextState = filterUsersSlice.reducer(
       initialState,
       toggleReportedByYou(),
     );
     expect(nextState.reportedByYou).toBe(true);
+    nextState = filterUsersSlice.reducer(nextState, toggleReportedByYou());
+    expect(nextState.reportedByYou).toBe(false);
   });
 
   it('should toggle showReportedUsers', () => {
-    const nextState = filterUsersSlice.reducer(
+    let nextState = filterUsersSlice.reducer(
       initialState,
       toggleShowReportedUsers(),
     );
     expect(nextState.showReportedUsers).toBe(true);
+    nextState = filterUsersSlice.reducer(nextState, toggleShowReportedUsers());
+    expect(nextState.showReportedUsers).toBe(false);
   });
 
   it('should set category', () => {
@@ -80,15 +86,6 @@ describe('filterUsersSlice', () => {
       toggleCategory({ category: UserCategory.Auditor }),
     );
     expect(nextState.categories).toStrictEqual([UserCategory.Auditor]);
-  });
-
-  it('should select all categories when the only one category selected is toggled', () => {
-    initialState.categories = [UserCategory.Auditor];
-    const nextState = filterUsersSlice.reducer(
-      initialState,
-      toggleCategory({ category: UserCategory.Auditor }),
-    );
-    expect(nextState.categories).toStrictEqual(INITIAL_USER_CATEGORIES);
   });
 
   it('sets the search results', () => {

--- a/src/features/users/store.ts
+++ b/src/features/users/store.ts
@@ -54,12 +54,21 @@ export const filterUsersSlice = createSlice({
     },
     toggleEndorsedByYou: (state) => {
       state.endorsedByYou = !state.endorsedByYou;
+      if (state.endorsedByYou) {
+        state.categories = [];
+      }
     },
     toggleReportedByYou: (state) => {
       state.reportedByYou = !state.reportedByYou;
+      if (state.reportedByYou) {
+        state.categories = [];
+      }
     },
     toggleShowReportedUsers: (state) => {
       state.showReportedUsers = !state.showReportedUsers;
+      if (state.showReportedUsers) {
+        state.categories = [];
+      }
     },
     toggleCategory: (
       state,
@@ -74,11 +83,6 @@ export const filterUsersSlice = createSlice({
       } else {
         // Otherwise, add it by creating a new array with the updated value.
         state.categories = [...state.categories, category];
-      }
-
-      // If no categories are selected, select all.
-      if (state.categories.length === 0) {
-        state.categories = INITIAL_USER_CATEGORIES;
       }
     },
     setCategory: (state, action: PayloadAction<UserCategory>) => {


### PR DESCRIPTION
## Description

Make Category filter non mandatory
Extra filters can be applied with or without category
When extra filters are selected, remove category explicitly

### Related ticket

Fixes #222 

### Type of change

- [ ] Chore
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
