### PR TITLE
feat: AAU, I can see user information when hovering the graph nodes

### DIFF
--- a/src/components/ConnectedNodes.test.tsx
+++ b/src/components/ConnectedNodes.test.tsx
@@ -1,7 +1,12 @@
-import { screen } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 
 import { ConnectedNodes, type ConnectedNodesProps } from './ConnectedNodes';
 import { render } from '../utils/test-utils';
+
+jest.mock('.', () => ({
+  ...jest.requireActual('.'),
+  Tooltip: () => <div data-testid="tooltip" />,
+}));
 
 describe('ConnectedNodes', () => {
   const testData: ConnectedNodesProps = {
@@ -34,11 +39,36 @@ describe('ConnectedNodes', () => {
     const nodeElements = screen.getAllByTestId('glow');
     expect(nodeElements).toHaveLength(3);
     const nodeElement = nodeElements[0] as any;
-    // eslint-disable-next-line no-restricted-globals
-    nodeElement.dispatchEvent(new MouseEvent('mouseover'));
+
+    act(() => {
+      // eslint-disable-next-line no-restricted-globals
+      nodeElement.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+    });
     expect(nodeElement.parentElement).toHaveStyle('filter: url(#glow)');
-    // eslint-disable-next-line no-restricted-globals
-    nodeElement.dispatchEvent(new MouseEvent('mouseout'));
+    act(() => {
+      // eslint-disable-next-line no-restricted-globals
+      nodeElement.dispatchEvent(new MouseEvent('mousemove', { bubbles: true }));
+    });
+    act(() => {
+      // eslint-disable-next-line no-restricted-globals
+      nodeElement.dispatchEvent(new MouseEvent('mouseout', { bubbles: true }));
+    });
     expect(nodeElement.parentElement).not.toHaveStyle('filter: url(#glow)');
+  });
+
+  it('redirects to the correct URL on node click', () => {
+    render(<ConnectedNodes data={testData} />);
+    const nodeElements = screen.getAllByTestId('jazzicon');
+    expect(nodeElements).toHaveLength(3);
+    const nodeElement = nodeElements[0] as any;
+
+    act(() => {
+      // eslint-disable-next-line no-restricted-globals
+      nodeElement.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const expectedUrl = `http://localhost/`;
+    // eslint-disable-next-line no-restricted-globals
+    expect(window.location.href).toBe(expectedUrl);
   });
 });

--- a/src/components/ConnectedNodes.tsx
+++ b/src/components/ConnectedNodes.tsx
@@ -243,7 +243,7 @@ export const ConnectedNodes: React.FC<{ data: ConnectedNodesProps }> = ({
         .attr('data-testid', 'jazzicon')
         .on('click', function (event, node) {
           const address = node.id;
-          const url = `${window.location.origin}/account/?address=${address}`;
+          const url = `${window.location.href.split('=')[0]}=${address}`;
           window.location.href = url;
         });
     }

--- a/src/components/ConnectedNodes.tsx
+++ b/src/components/ConnectedNodes.tsx
@@ -1,7 +1,9 @@
 /* eslint-disable */
 import Jazzicon from '@metamask/jazzicon';
 import * as d3 from 'd3';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { Address } from 'viem';
+import { Tooltip, UserNodeTooltip } from '.';
 
 interface Node extends d3.SimulationNodeDatum {
   id: string;
@@ -27,6 +29,7 @@ export const ConnectedNodes: React.FC<{ data: ConnectedNodesProps }> = ({
   data,
 }) => {
   const svgRef = useRef<SVGSVGElement>(null);
+  const [tooltip, setTooltip] = useState({ visible: false, position: { x: 0, y: 0 }, content: null as any });
 
   useEffect(() => {
     const width = 1248;
@@ -104,7 +107,7 @@ export const ConnectedNodes: React.FC<{ data: ConnectedNodesProps }> = ({
 
     const jazzicons = createJazzicons();
 
-    applyGlowToJazzions();
+    applyGlowAndTooltipToJazzions();
 
     convertJazziconsToCircle();
 
@@ -156,7 +159,7 @@ export const ConnectedNodes: React.FC<{ data: ConnectedNodesProps }> = ({
       });
     }
 
-    function applyGlowToJazzions() {
+    function applyGlowAndTooltipToJazzions() {
       jazzicons
         .append('circle')
         .data(nodes)
@@ -165,13 +168,25 @@ export const ConnectedNodes: React.FC<{ data: ConnectedNodesProps }> = ({
         .attr('r', 40) // Use the buffer radius
         .attr('opacity', 0) // Make the circle invisible
         .attr('data-testid', 'glow')
-        .on('mouseover', function () {
-          // Apply glow effect on mouseover
+        .on('mouseover', function (event, node) {
           d3.select(this.parentNode).style('filter', 'url(#glow)');
+          setTooltip({
+            visible: true,
+            position: { x: event.pageX, y: event.pageY },
+            content: <UserNodeTooltip address={node.id as Address} />,
+          });
+          d3.select(this).style('cursor', 'pointer');
         })
-        .on('mouseout', function () {
-          // Remove the glow effect on mouseout
+        .on('mousemove', function (event) {
+          setTooltip((prev) => ({
+            ...prev,
+            position: { x: event.pageX, y: event.pageY },
+          }));
+        })
+        .on('mouseout', function (event, node) {
           d3.select(this.parentNode).style('filter', null);
+          setTooltip({ visible: false, position: { x: 0, y: 0 }, content: null });
+          d3.select(this).style('cursor', 'default');
         });
     }
 
@@ -225,7 +240,12 @@ export const ConnectedNodes: React.FC<{ data: ConnectedNodesProps }> = ({
             })`,
         )
         .attr('id', (node: any) => `${node.id})`)
-        .attr('data-testid', 'jazzicon');
+        .attr('data-testid', 'jazzicon')
+        .on('click', function (event, node) {
+          const address = node.id;
+          const url = `/account/?address=${address}`;
+          window.location.href = url;
+        });
     }
 
     function createGlowObject() {
@@ -241,5 +261,8 @@ export const ConnectedNodes: React.FC<{ data: ConnectedNodesProps }> = ({
     }
   }, [data]);
 
-  return <svg ref={svgRef} />;
+  return  <>
+  <svg ref={svgRef} />
+  <Tooltip visible={tooltip.visible} position={tooltip.position} content={tooltip.content} />
+</>;
 };

--- a/src/components/ConnectedNodes.tsx
+++ b/src/components/ConnectedNodes.tsx
@@ -243,7 +243,7 @@ export const ConnectedNodes: React.FC<{ data: ConnectedNodesProps }> = ({
         .attr('data-testid', 'jazzicon')
         .on('click', function (event, node) {
           const address = node.id;
-          const url = `/account/?address=${address}`;
+          const url = `${window.location.origin}/account/?address=${address}`;
           window.location.href = url;
         });
     }

--- a/src/components/Tooltip.test.tsx
+++ b/src/components/Tooltip.test.tsx
@@ -1,0 +1,30 @@
+import { Tooltip } from './Tooltip';
+import { render } from '../utils/test-utils';
+
+describe('Tooltip', () => {
+  it('renders correctly when visible is true', () => {
+    const position = { x: 100, y: 200 };
+    const content = 'Tooltip Content';
+
+    const { getByText } = render(
+      <Tooltip visible={true} position={position} content={content} />,
+    );
+
+    const tooltipElement = getByText(content);
+    expect(tooltipElement).toBeInTheDocument();
+    expect(tooltipElement).toHaveStyle(`top: ${position.y}px`);
+    expect(tooltipElement).toHaveStyle(`left: ${position.x}px`);
+  });
+
+  it('does not render when visible is false', () => {
+    const position = { x: 100, y: 200 };
+    const content = 'Tooltip Content';
+
+    const { queryByText } = render(
+      <Tooltip visible={false} position={position} content={content} />,
+    );
+
+    const tooltipElement = queryByText(content);
+    expect(tooltipElement).not.toBeInTheDocument();
+  });
+});

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -1,0 +1,27 @@
+export const Tooltip = ({
+  visible,
+  position,
+  content,
+}: {
+  visible: boolean;
+  position: { x: number; y: number };
+  content: any;
+}) => {
+  if (!visible) {
+    return null;
+  }
+
+  const style: React.CSSProperties = {
+    position: 'fixed',
+    top: position.y,
+    left: position.x,
+    background: 'rgba(0, 0, 0, 0.75)',
+    borderRadius: '4px',
+    color: '#fff',
+    padding: '5px 10px',
+    fontSize: '12px',
+    pointerEvents: 'none' as const,
+  };
+
+  return <div style={style}>{content}</div>;
+};

--- a/src/components/UserNodeTooltip.test.tsx
+++ b/src/components/UserNodeTooltip.test.tsx
@@ -1,0 +1,49 @@
+import { useEnsName } from 'wagmi';
+
+import { UserNodeTooltip } from './UserNodeTooltip';
+import { VALID_ACCOUNT_1, render } from '../utils/test-utils';
+
+jest.mock('wagmi', () => ({
+  useEnsName: jest.fn(),
+  createConfig: jest.fn(),
+  mainnet: { id: 1 },
+}));
+
+const buildEnsNameMock = (name?: string, isLoading = false) => {
+  const mockUseEnsName = useEnsName as jest.Mock;
+  mockUseEnsName.mockImplementation(() => ({
+    data: name,
+    isLoading,
+  }));
+};
+
+describe('UserNodeTooltip', () => {
+  it('displays address and ENS name if available', () => {
+    const address = VALID_ACCOUNT_1;
+    buildEnsNameMock('ens.mock.name');
+
+    const { getByText } = render(<UserNodeTooltip address={address} />);
+
+    const addressElement = getByText(`Address: ${address}`);
+    const ensNameElement = getByText(`ENS: ens.mock.name`);
+
+    expect(addressElement).toBeInTheDocument();
+    expect(ensNameElement).toBeInTheDocument();
+  });
+
+  it('displays only address if ENS name is not available', () => {
+    const address = VALID_ACCOUNT_1;
+    // Mock the useEnsName hook to return no data
+    buildEnsNameMock('');
+
+    const { getByText, queryByText } = render(
+      <UserNodeTooltip address={address} />,
+    );
+
+    const addressElement = getByText(`Address: ${address}`);
+    const ensNameElement = queryByText(/^ENS:/u); // Regular expression to match text starting with "ENS:"
+
+    expect(addressElement).toBeInTheDocument();
+    expect(ensNameElement).not.toBeInTheDocument();
+  });
+});

--- a/src/components/UserNodeTooltip.tsx
+++ b/src/components/UserNodeTooltip.tsx
@@ -1,0 +1,25 @@
+import type { FunctionComponent } from 'react';
+import type { Address } from 'viem';
+import { mainnet, useEnsName } from 'wagmi';
+
+export type UserNodeTooltipProps = {
+  address: Address;
+};
+
+export const UserNodeTooltip: FunctionComponent<UserNodeTooltipProps> = ({
+  address,
+}) => {
+  const { data: ensName } = useEnsName({
+    address,
+    chainId: mainnet.id,
+  });
+
+  return (
+    <div>
+      <div>Address: {address}</div>
+      {ensName && <div>ENS: {ensName}</div>}
+    </div>
+  );
+};
+
+export default UserNodeTooltip;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -27,3 +27,5 @@ export * from './JazzIcon';
 export * from './IconMenu';
 export * from './IssuersListModal';
 export * from './MenuItemCard';
+export * from './Tooltip';
+export * from './UserNodeTooltip';


### PR DESCRIPTION
## Description

Adds a tooltip when hovering the graph nodes to display the user details
Adds a click action on graph nodes to link to the user's profile page

### Related ticket

Fixes #227 

### Type of change

- [ ] Chore
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
