### PR TITLE
fix: Auditor badge not displayed

### DIFF
--- a/src/pages/account/index.test.tsx
+++ b/src/pages/account/index.test.tsx
@@ -120,6 +120,7 @@ describe('Account Profile page', () => {
     );
     mockDispatch.mockImplementationOnce(async () => Promise.resolve());
     mockDispatch.mockImplementationOnce(async () => Promise.resolve());
+    mockDispatch.mockImplementationOnce(async () => Promise.resolve());
 
     const address = VALID_ACCOUNT_1;
     mockGetAddress.mockReturnValue(address);
@@ -150,6 +151,7 @@ describe('Account Profile page', () => {
       Promise.reject(new Error()),
     );
     mockDispatch.mockImplementationOnce(async () => Promise.resolve());
+    mockDispatch.mockImplementationOnce(async () => Promise.resolve());
 
     const address = VALID_ACCOUNT_1;
     mockGetAddress.mockReturnValue(address);
@@ -175,6 +177,38 @@ describe('Account Profile page', () => {
   it('renders if `fetchAssertionsByIssuer` failed', async () => {
     const mockDispatch = jest.fn();
     mockUseDispatch.mockReturnValue(mockDispatch);
+    mockDispatch.mockImplementationOnce(async () => Promise.resolve());
+    mockDispatch.mockImplementationOnce(async () => Promise.resolve());
+    mockDispatch.mockImplementationOnce(async () =>
+      Promise.reject(new Error()),
+    );
+    mockDispatch.mockImplementationOnce(async () => Promise.resolve());
+
+    const address = VALID_ACCOUNT_1;
+    mockGetAddress.mockReturnValue(address);
+    mockUseAccount.mockReturnValue({
+      address: null,
+      isConnected: false,
+    });
+
+    const mockLocationSearchParam = {
+      search: new URLSearchParams({ address }),
+    };
+
+    const { queryByText, queryByTestId } = render(
+      <AccountProfilePage location={mockLocationSearchParam} />,
+    );
+
+    expect(
+      queryByText("The page you're looking for can't be found."),
+    ).not.toBeInTheDocument();
+    expect(queryByTestId('account-info')).toBeInTheDocument();
+  });
+
+  it('renders if `fetchAuditors` failed', async () => {
+    const mockDispatch = jest.fn();
+    mockUseDispatch.mockReturnValue(mockDispatch);
+    mockDispatch.mockImplementationOnce(async () => Promise.resolve());
     mockDispatch.mockImplementationOnce(async () => Promise.resolve());
     mockDispatch.mockImplementationOnce(async () => Promise.resolve());
     mockDispatch.mockImplementationOnce(async () =>

--- a/src/pages/account/index.tsx
+++ b/src/pages/account/index.tsx
@@ -7,6 +7,7 @@ import { type FunctionComponent, useEffect } from 'react';
 import { useAccount } from 'wagmi';
 
 import banner from '../../assets/images/seo/home.png';
+import { fetchAuditors } from '../../features';
 import {
   AccountInfo,
   AccountReport,
@@ -46,6 +47,7 @@ const AccountPage: FunctionComponent<AccountPageProps> = ({ location }) => {
       dispatch(fetchAssertionsByIssuer(address)).catch((error) =>
         console.log(error),
       );
+      dispatch(fetchAuditors()).catch((error) => console.log(error));
     }
   }, [dispatch, accountVCBuilder, address]);
 


### PR DESCRIPTION
## Description

Fixes the case where the 'Auditor' badge was not displayed

### Related ticket

Fixes #164 

### Type of change

- [ ] Chore
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
